### PR TITLE
Add failing test for error keys

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -163,8 +163,12 @@ describe('Unit | Utility | changeset', () => {
   test('can get nested values in the errors object', () => {
     let dummyChangeset = Changeset(dummyModel, dummyValidator);
     dummyChangeset.set('org.usa.ny', '');
+    dummyChangeset.set('name', '');
 
-    let expectedErrors = [{ key: 'org.usa.ny', validation: 'must be present', value: '' }];
+    let expectedErrors = [
+      { key: 'org.usa.ny', validation: 'must be present', value: '' },
+      { key: 'name', validation: 'too short', value: '' }
+    ];
     expect(dummyChangeset.get('errors')).toEqual(expectedErrors);
   });
 


### PR DESCRIPTION
Same as https://github.com/poteto/ember-changeset/pull/400. 

<img width="674" alt="Screen Shot 2020-01-11 at 11 24 30 AM" src="https://user-images.githubusercontent.com/230476/72209597-f630f900-3464-11ea-8e28-82ae817823c2.png">


