### PR TITLE
Don't stringify and parse the error object to and from json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,9 +192,7 @@ export class BufferedChangeset implements IChangeset {
   }
 
   get error() {
-    let obj: Errors<any> = this[ERRORS];
-    // TODO: whyy?
-    return JSON.parse(JSON.stringify(obj));
+    return this[ERRORS];
   }
 
   get data() {


### PR DESCRIPTION
Stringifying and parsing again will throw when `obj` has a circular
structure which can exist when e.g. ember data relationships are values
in the changesets underlying object. Fixes #19