### PR TITLE
Handle validation and trigger AFTER_VALIDATION_EVENT in the right order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -656,14 +656,16 @@ export class BufferedChangeset implements IChangeset {
     if (isPromise(validation)) {
       this._setIsValidating(key, true);
 
-      return (validation as Promise<ValidationResult>).then(
-        (resolvedValidation: ValidationResult) => {
+      return (validation as Promise<ValidationResult>)
+        .then((resolvedValidation: ValidationResult) => {
           this._setIsValidating(key, false);
-          this.trigger(AFTER_VALIDATION_EVENT, key);
 
           return this._handleValidation(resolvedValidation, { key, value });
-        }
-      );
+        })
+        .then(result => {
+          this.trigger(AFTER_VALIDATION_EVENT, key);
+          return result;
+        });
     }
 
     let result = this._handleValidation(validation as ValidationResult, { key, value });


### PR DESCRIPTION
The order of those was different for a promise validation vs a plain
function validation. The trigger was called *before* the validation
handler when the validation is a promise.
Since the errors are added to the changeset in `_handleValidation` the
trigger for promise validations was called before that error was set.