### PR TITLE
Fixed snapshot behavior with nested keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -555,8 +555,8 @@ export class BufferedChangeset implements IChangeset {
     let errors: Errors<any> = this[ERRORS];
 
     return {
-      changes: keys(changes).reduce((newObj: Changes, key: keyof Changes) => {
-        newObj[key] = changes[key].value;
+      changes: getKeyValues(changes).reduce((newObj: Changes, { key, value }) => {
+        newObj[key] = value;
         return newObj;
       }, {}),
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1621,6 +1621,25 @@ describe('Unit | Utility | changeset', () => {
     expect(snapshot).toEqual(expectedResult);
   });
 
+  it('#snapshot creates a snapshot of the changeset with nested values', () => {
+    let dummyChangeset = Changeset(dummyModel, dummyValidator);
+    dummyChangeset.set('name', 'Pokemon Go');
+    dummyChangeset.set('password', false);
+    dummyChangeset.set('org.usa.ny', 'foo');
+
+    let snapshot = dummyChangeset.snapshot();
+    let expectedResult = {
+      changes: {
+        name: 'Pokemon Go',
+        password: false,
+        'org.usa.ny': 'foo'
+      },
+      errors: { password: { validation: ['foo', 'bar'], value: false } }
+    };
+
+    expect(snapshot).toEqual(expectedResult);
+  });
+
   /**
    * #restore
    */
@@ -1637,6 +1656,26 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyChangesetB.isInvalid).toBeTruthy();
     expect(get(dummyChangesetB, 'change.name')).toBe('Pokemon Go');
     expect(get(dummyChangesetB, 'error.password')).toEqual({
+      validation: ['foo', 'bar'],
+      value: false
+    });
+  });
+
+  it('#restore restores a snapshot of the changeset with nested values', () => {
+    let dummyChangesetA = Changeset(dummyModel, dummyValidator);
+    let dummyChangesetB = Changeset(dummyModel, dummyValidator);
+    dummyChangesetA.set('name', 'Pokemon Go');
+    dummyChangesetA.set('password', false);
+    dummyChangesetA.set('org.usa.ny', 'foo');
+    let snapshot = dummyChangesetA.snapshot();
+
+    expect(dummyChangesetB.isValid).toBeTruthy();
+    dummyChangesetB.restore(snapshot);
+    expect(dummyChangesetB.isInvalid).toBeTruthy();
+    expect(dummyChangesetB.get('name')).toBe('Pokemon Go');
+    expect(dummyChangesetB.get('password')).toBe(false);
+    expect(dummyChangesetB.get('org.usa.ny')).toBe('foo');
+    expect(dummyChangesetB.error.password).toEqual({
       validation: ['foo', 'bar'],
       value: false
     });


### PR DESCRIPTION
@snewcomer I would need some help/advice how to update `restore()` method.

In v2 branch of ember-changeset, `_changes` object was stored as a map/hash with keys in format `foo` or `foo.bar.baz`.

validated-changeset stores `_changes` in format like
```
{
  foo: {
    bar: {
      baz: 'abc'
    }
  }
}
```

Because of that changes I'm not sure what would you consider the most efficient way of restoring Changeset from snapshot.

The new test `#restore restores a snapshot of the changeset with nested values` has been created and it currently fails as no changes to `restore()` have been made.