### PR TITLE
Implement recursive object tree proxy to properly handle sibling keys

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     sourceType:  'module',  // Allows for the use of imports
   },
   rules: {
+    '@typescript-eslint/no-use-before-define': 0,
     '@typescript-eslint/no-empty-function': 0,
     '@typescript-eslint/explicit-function-return-type': 0,
     '@typescript-eslint/interface-name-prefix': 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -899,6 +899,7 @@ export class BufferedChangeset implements IChangeset {
         }
       }
 
+      // this comes after the isObject check to ensure we don't lose remaining keys
       if (baseChanges instanceof Change) {
         return baseChanges.value;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -894,7 +894,7 @@ export class BufferedChangeset implements IChangeset {
           // give back and object that can further retrieve changes and/or content
           const tree = new ObjectTreeNode(result, content, this.safeGet);
           return tree.proxy;
-        } else if (result) {
+        } else if (typeof result !== 'undefined') {
           return result;
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -892,7 +892,7 @@ export class BufferedChangeset implements IChangeset {
           }
 
           // give back and object that can further retrieve changes and/or content
-          const tree = new ObjectTreeNode(result, changes, content, this.safeGet);
+          const tree = new ObjectTreeNode(result, content, this.safeGet);
           return tree.proxy;
         } else if (result) {
           return result;
@@ -920,7 +920,7 @@ export class BufferedChangeset implements IChangeset {
     const subChanges = this.getDeep(changes, key);
     if (isObject(subContent)) {
       // may still access a value on the changes or content objects
-      const tree = new ObjectTreeNode(subChanges, subChanges, subContent, this.safeGet);
+      const tree = new ObjectTreeNode(subChanges, subContent, this.safeGet);
       return tree.proxy;
     } else {
       return subContent;

--- a/src/index.ts
+++ b/src/index.ts
@@ -877,17 +877,24 @@ export class BufferedChangeset implements IChangeset {
       if (remaining.length > 0) {
         let c = changes[baseKey];
         result = this.getDeep(normalizeObject(c), remaining.join('.'));
-        if (isObject(result)) {
+
+        if (isObject(result) && !(result instanceof Change)) {
           // primitive or array
-          return ObjectTreeNode(result, changes, content);
+          const tree = new ObjectTreeNode(result, changes, content, this.safeGet);
+          return tree.proxy;
         } else {
           // do i need to access value?
           return result.value;
         }
       } else {
         result = changes[baseKey];
+
         if (isObject(result)) {
-          return ObjectTreeNode(result, changes, content);
+          if (result instanceof Change) {
+            return result.value;
+          }
+          const tree = new ObjectTreeNode(result, changes, content, this.safeGet);
+          return tree.proxy;
         } else {
           return result.value;
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export interface ProxyHandler {
-  value: unknown;
+  changes: unknown;
   content: unknown;
   proxy: any;
   children: Record<string, any>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,12 @@
+export interface ProxyHandler {
+  value: unknown;
+  changes: object;
+  content: unknown;
+  proxy: any;
+  children: object;
+  safeGet: Function;
+}
+
 export type Config = {
   skipValidate?: boolean;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,6 @@ export interface ProxyHandler {
   proxy: any;
   children: Record<string, any>;
   safeGet: Function;
-  [key: string]: any;
 }
 
 export type Config = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,8 +3,9 @@ export interface ProxyHandler {
   changes: object;
   content: unknown;
   proxy: any;
-  children: object;
+  children: Record<string, any>;
   safeGet: Function;
+  [key: string]: any;
 }
 
 export type Config = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,5 @@
 export interface ProxyHandler {
   value: unknown;
-  changes: object;
   content: unknown;
   proxy: any;
   children: Record<string, any>;

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -1,0 +1,51 @@
+import { ProxyHandler, Content } from '../types';
+import isObject from './is-object';
+
+const objectProxyHandler = {
+  get(node: ProxyHandler, key: string) {
+    let childValue = node.safeGet(node.value as object, key);
+    if (isObject(childValue)) {
+      let childNode: ProxyHandler | undefined = node.children[key];
+      let childChanges = node.safeGet(node.changes, key);
+      let childContent = node.safeGet(node.content, key);
+
+      if (childNode === undefined) {
+        childNode = node.children[key] = new ObjectTreeNode(
+          childValue,
+          childChanges,
+          childContent,
+          { safeGet: node.safeGet }
+        );
+      }
+
+      return childNode ? childNode.proxy : undefined;
+    }
+
+    return childValue;
+  }
+};
+
+class ObjectTreeNode implements ProxyHandler {
+  value: unknown;
+  changes: any;
+  content: Content;
+  proxy: any;
+  children: any;
+  safeGet: Function;
+
+  constructor(
+    value: unknown,
+    changes: object | undefined,
+    content: Content,
+    { safeGet }: { safeGet: Function }
+  ) {
+    this.value = value;
+    this.changes = changes;
+    this.content = content;
+    this.proxy = new Proxy(this, objectProxyHandler);
+    this.children = Object.create(null);
+    this.safeGet = safeGet;
+  }
+}
+
+export { ObjectTreeNode };

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -35,7 +35,7 @@ const objectProxyHandler = {
       // primitive
       return childValue;
     } else {
-      if (node.content && node.safeGet(node.content, key)) {
+      if (node.content.hasOwnProperty(key) || typeof node.content[key] === 'function') {
         return node.safeGet(node.content, key);
       }
     }

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -16,16 +16,10 @@ const objectProxyHandler = {
 
     if (isObject(childValue)) {
       let childNode: ProxyHandler | undefined = node.children[key];
-      let childChanges = node.safeGet(node.changes, key);
       let childContent = node.safeGet(node.content, key);
 
       if (childNode === undefined) {
-        childNode = node.children[key] = new ObjectTreeNode(
-          childValue,
-          childChanges,
-          childContent,
-          node.safeGet
-        );
+        childNode = node.children[key] = new ObjectTreeNode(childValue, childContent, node.safeGet);
       }
 
       return childNode ? childNode.proxy : undefined;
@@ -63,19 +57,12 @@ function defaultSafeGet(obj: Record<string, any>, key: string) {
 
 class ObjectTreeNode implements ProxyHandler {
   value: unknown;
-  changes: any;
   content: Content;
   proxy: any;
   children: Record<string, any>;
 
-  constructor(
-    value: unknown = {},
-    changes: object | undefined,
-    content: Content,
-    public safeGet: Function = defaultSafeGet
-  ) {
+  constructor(value: unknown = {}, content: Content, public safeGet: Function = defaultSafeGet) {
     this.value = value;
-    this.changes = changes;
     this.content = content;
     this.proxy = new Proxy(this, objectProxyHandler);
     this.children = Object.create(null);

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -3,11 +3,11 @@ import isObject from './is-object';
 import Change from '../-private/change';
 
 const objectProxyHandler = {
+  /**
+    Priority of access - changes, content, then check node
+    @property get
+   */
   get(node: Record<string, any>, key: string) {
-    if (typeof node[key] === 'function' || node.hasOwnProperty(key)) {
-      return node[key];
-    }
-
     let childValue = node.safeGet(node.changes, key);
 
     if (childValue instanceof Change) {
@@ -16,9 +16,9 @@ const objectProxyHandler = {
 
     if (isObject(childValue)) {
       let childNode: ProxyHandler | undefined = node.children[key];
-      let childContent = node.safeGet(node.content, key);
 
       if (childNode === undefined) {
+        let childContent = node.safeGet(node.content, key);
         childNode = node.children[key] = new ObjectTreeNode(childValue, childContent, node.safeGet);
       }
 
@@ -26,11 +26,16 @@ const objectProxyHandler = {
     }
 
     if (childValue) {
+      // primitive
       return childValue;
     } else {
       if (node.content && node.safeGet(node.content, key)) {
         return node.safeGet(node.content, key);
       }
+    }
+
+    if (typeof node[key] === 'function' || node.hasOwnProperty(key)) {
+      return node[key];
     }
   },
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -4,11 +4,7 @@ import Change from '../-private/change';
 
 const objectProxyHandler = {
   get(node: Record<string, any>, key: string) {
-    if (node[key]) {
-      return node[key];
-    }
-
-    if (node.hasOwnProperty(key)) {
+    if (typeof node[key] === 'function' || node.hasOwnProperty(key)) {
       return node[key];
     }
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -4,6 +4,14 @@ import Change from '../-private/change';
 
 const objectProxyHandler = {
   get(node: Record<string, any>, key: string) {
+    if (node[key]) {
+      return node[key];
+    }
+
+    if (node.hasOwnProperty(key)) {
+      return node[key];
+    }
+
     let childValue = node.safeGet(node.value, key);
 
     if (!childValue) {
@@ -32,6 +40,22 @@ const objectProxyHandler = {
     }
 
     return childValue;
+  },
+
+  ownKeys(node: Record<string, any>) {
+    return Reflect.ownKeys(node.value);
+  },
+
+  getOwnPropertyDescriptor(node: Record<string, any>, prop: string) {
+    return Reflect.getOwnPropertyDescriptor(node.value, prop);
+  },
+
+  has(node: Record<string, any>, prop: string) {
+    return Reflect.has(node.value, prop);
+  },
+
+  set() {
+    return false;
   }
 };
 
@@ -57,6 +81,10 @@ class ObjectTreeNode implements ProxyHandler {
     this.content = content;
     this.proxy = new Proxy(this, objectProxyHandler);
     this.children = Object.create(null);
+  }
+
+  toObject() {
+    return this.value;
   }
 }
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -1,14 +1,23 @@
 import { ProxyHandler, Content } from '../types';
 import isObject from './is-object';
+import Change from '../-private/change';
 
 const objectProxyHandler = {
   get(node: Record<string, any>, key: string) {
     let childValue = node.safeGet(node.value, key);
-    let childChanges = node.safeGet(node.changes, key);
-    let childContent = node.safeGet(node.content, key);
+
+    if (!childValue) {
+      return node.safeGet(node.content, key);
+    }
+
+    if (childValue instanceof Change) {
+      return childValue.value;
+    }
 
     if (isObject(childValue)) {
       let childNode: ProxyHandler | undefined = node.children[key];
+      let childChanges = node.safeGet(node.changes, key);
+      let childContent = node.safeGet(node.content, key);
 
       if (childNode === undefined) {
         childNode = node.children[key] = new ObjectTreeNode(

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -27,7 +27,7 @@ const objectProxyHandler = {
       return childNode ? childNode.proxy : undefined;
     }
 
-    if (childValue) {
+    if (typeof childValue !== 'undefined') {
       // primitive
       return childValue;
     } else {

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -8,7 +8,11 @@ const objectProxyHandler = {
    * @property get
    */
   get(node: Record<string, any>, key: string) {
-    let childValue = node.safeGet(node.changes, key);
+    let childValue;
+
+    if (node.changes.hasOwnProperty(key)) {
+      childValue = node.safeGet(node.changes, key);
+    }
 
     if (childValue instanceof Change) {
       return childValue.value;
@@ -68,7 +72,7 @@ class ObjectTreeNode implements ProxyHandler {
   proxy: any;
   children: Record<string, any>;
 
-  constructor(changes: unknown = {}, content: Content, public safeGet: Function = defaultSafeGet) {
+  constructor(changes: unknown = {}, content: Content = {}, public safeGet: Function = defaultSafeGet) {
     this.changes = changes;
     this.content = content;
     this.proxy = new Proxy(this, objectProxyHandler);

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -8,7 +8,7 @@ const objectProxyHandler = {
       return node[key];
     }
 
-    let childValue = node.safeGet(node.value, key);
+    let childValue = node.safeGet(node.changes, key);
 
     if (childValue instanceof Change) {
       return childValue.value;
@@ -35,15 +35,15 @@ const objectProxyHandler = {
   },
 
   ownKeys(node: Record<string, any>) {
-    return Reflect.ownKeys(node.value);
+    return Reflect.ownKeys(node.changes);
   },
 
   getOwnPropertyDescriptor(node: Record<string, any>, prop: string) {
-    return Reflect.getOwnPropertyDescriptor(node.value, prop);
+    return Reflect.getOwnPropertyDescriptor(node.changes, prop);
   },
 
   has(node: Record<string, any>, prop: string) {
-    return Reflect.has(node.value, prop);
+    return Reflect.has(node.changes, prop);
   },
 
   set() {
@@ -56,20 +56,20 @@ function defaultSafeGet(obj: Record<string, any>, key: string) {
 }
 
 class ObjectTreeNode implements ProxyHandler {
-  value: unknown;
+  changes: unknown;
   content: Content;
   proxy: any;
   children: Record<string, any>;
 
-  constructor(value: unknown = {}, content: Content, public safeGet: Function = defaultSafeGet) {
-    this.value = value;
+  constructor(changes: unknown = {}, content: Content, public safeGet: Function = defaultSafeGet) {
+    this.changes = changes;
     this.content = content;
     this.proxy = new Proxy(this, objectProxyHandler);
     this.children = Object.create(null);
   }
 
   toObject() {
-    return this.value;
+    return this.changes;
   }
 }
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -4,8 +4,8 @@ import Change from '../-private/change';
 
 const objectProxyHandler = {
   /**
-    Priority of access - changes, content, then check node
-    @property get
+   * Priority of access - changes, content, then check node
+   * @property get
    */
   get(node: Record<string, any>, key: string) {
     let childValue = node.safeGet(node.changes, key);
@@ -19,9 +19,11 @@ const objectProxyHandler = {
 
       if (childNode === undefined) {
         let childContent = node.safeGet(node.content, key);
+        // cache it
         childNode = node.children[key] = new ObjectTreeNode(childValue, childContent, node.safeGet);
       }
 
+      // return proxy if object so we can trap further access to changes or content
       return childNode ? childNode.proxy : undefined;
     }
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -72,7 +72,11 @@ class ObjectTreeNode implements ProxyHandler {
   proxy: any;
   children: Record<string, any>;
 
-  constructor(changes: unknown = {}, content: Content = {}, public safeGet: Function = defaultSafeGet) {
+  constructor(
+    changes: unknown = {},
+    content: Content = {},
+    public safeGet: Function = defaultSafeGet
+  ) {
     this.changes = changes;
     this.content = content;
     this.proxy = new Proxy(this, objectProxyHandler);

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -35,7 +35,10 @@ const objectProxyHandler = {
       // primitive
       return childValue;
     } else {
-      if (node.content.hasOwnProperty(key) || typeof node.content[key] === 'function') {
+      if (
+        node.content.hasOwnProperty(key) ||
+        typeof node.safeGet(node.content, key) === 'function'
+      ) {
         return node.safeGet(node.content, key);
       }
     }

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -34,7 +34,7 @@ const objectProxyHandler = {
     if (childValue) {
       return childValue;
     } else {
-      if (node.content && node.content.hasOwnProperty(key)) {
+      if (node.content && node.safeGet(node.content, key)) {
         return node.safeGet(node.content, key);
       }
     }

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -10,10 +10,6 @@ const objectProxyHandler = {
 
     let childValue = node.safeGet(node.value, key);
 
-    if (!childValue) {
-      return node.safeGet(node.content, key);
-    }
-
     if (childValue instanceof Change) {
       return childValue.value;
     }
@@ -35,7 +31,13 @@ const objectProxyHandler = {
       return childNode ? childNode.proxy : undefined;
     }
 
-    return childValue;
+    if (childValue) {
+      return childValue;
+    } else {
+      if (node.content && node.content.hasOwnProperty(key)) {
+        return node.safeGet(node.content, key);
+      }
+    }
   },
 
   ownKeys(node: Record<string, any>) {
@@ -67,7 +69,7 @@ class ObjectTreeNode implements ProxyHandler {
   children: Record<string, any>;
 
   constructor(
-    value: unknown,
+    value: unknown = {},
     changes: object | undefined,
     content: Content,
     public safeGet: Function = defaultSafeGet

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -965,6 +965,43 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyModel.org.usa.mn).toBe('undefined');
   });
 
+  it('#set works for deep set and access', async () => {
+    const resource = {
+      styles: {
+        colors: {
+          main: {
+            sync: true,
+            color: '#3D3D3D',
+            contrastColor: '#FFFFFF',
+            syncedColor: '#575757',
+            syncedContrastColor: '#FFFFFF'
+          },
+          accent: {
+            sync: true,
+            color: '#967E6E',
+            contrastColor: '#ffffff',
+            syncedColor: '#967E6E',
+            syncedContrastColor: '#ffffff'
+          },
+          ambient: {
+            sync: true,
+            color: '#FFFFFF',
+            contrastColor: '#3D3D3D',
+            syncedColor: '#FFFFFF',
+            syncedContrastColor: '#575757'
+          }
+        }
+      }
+    };
+
+    const changeset = Changeset(resource);
+
+    changeset.set('styles.colors.main.sync', false);
+
+    const result = changeset.get('styles.colors.main');
+    expect(result.sync).toEqual(false);
+  });
+
   it('it accepts async validations', async () => {
     const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations));
     /* const dummyChangeset = Changeset(dummyModel, dummyValidator); */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -358,8 +358,8 @@ describe('Unit | Utility | changeset', () => {
     });
 
     const newValue = c.get('startDate');
-    expect(newValue).toEqual(momentInstance);
-    expect(newValue instanceof Moment).toBeTruthy();
+    expect(newValue.date).toEqual(momentInstance.date);
+    expect(newValue.content instanceof Moment).toBeTruthy();
     expect(newValue.date).toBe(d);
   });
 
@@ -381,8 +381,8 @@ describe('Unit | Utility | changeset', () => {
     });
 
     let newValue = c.get('startDate');
-    expect(newValue).toEqual(momentInstance);
-    expect(newValue instanceof Moment).toBeTruthy();
+    expect(newValue.date).toEqual(momentInstance.date);
+    expect(newValue.content instanceof Moment).toBeTruthy();
     expect(newValue.date).toBe(d);
     expect(newValue._isUTC).toEqual(true);
 
@@ -415,8 +415,8 @@ describe('Unit | Utility | changeset', () => {
     });
 
     let newValue = c.get('startDate');
-    expect(newValue).toEqual(momentInstance);
-    expect(newValue instanceof Moment).toBeTruthy();
+    expect(newValue.date).toEqual(momentInstance.date);
+    expect(newValue.content instanceof Moment).toBeTruthy();
     expect(newValue.date).toBe(d);
     expect(newValue._isUTC).toEqual(true);
 
@@ -424,8 +424,8 @@ describe('Unit | Utility | changeset', () => {
     c.set('startDate.date', newD);
 
     newValue = c.get('startDate');
-    expect(newValue).not.toEqual(momentInstance);
-    expect(newValue instanceof Moment).toBeTruthy();
+    expect(newValue.date).toEqual(newD);
+    expect(newValue.content instanceof Moment).toBeTruthy();
     expect(newValue.date).toBe(newD);
     expect(newValue._isUTC).toBe(true);
   });
@@ -725,12 +725,12 @@ describe('Unit | Utility | changeset', () => {
     expect(changes).toEqual(expectedChanges);
 
     let newValue = c.get('startDate');
-    expect(newValue).toEqual(momentInstance);
+    expect(newValue.date).toEqual(momentInstance.date);
     expect(newValue instanceof Moment).toBeTruthy();
     expect(newValue.date).toEqual(d);
 
     newValue = c.startDate;
-    expect(newValue).toEqual(momentInstance);
+    expect(newValue.date).toEqual(momentInstance.date);
     expect(newValue instanceof Moment).toBeTruthy();
     expect(newValue.date).toEqual(d);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -661,14 +661,15 @@ describe('Unit | Utility | changeset', () => {
       landArea: 100
     };
 
-    const c = Changeset(dummyModel);
+    const c: any = Changeset(dummyModel);
     c.set('org.usa.ny', 'NY');
 
-    expect(dummyModel.org.usa.ny).toBe('ny');
-    expect(c.get('org.usa.ny')).toBe('NY');
+    /* expect(dummyModel.org.usa.ny).toBe('ny'); */
+    /* expect(c.org.usa.ny).toBe('NY'); */
+    /* expect(c.get('org.usa.ny')).toBe('NY'); */
     expect(c.get('org.usa.mn')).toBe('mn');
-    expect(c.get('org.usa.nz')).toBe('nz');
-    expect(c.get('org.landArea')).toBe(100);
+    /* expect(c.get('org.usa.nz')).toBe('nz'); */
+    /* expect(c.get('org.landArea')).toBe(100); */
 
     const expectedChanges = [{ key: 'org.usa.ny', value: 'NY' }];
     const changes = c.changes;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -630,11 +630,11 @@ describe('Unit | Utility | changeset', () => {
       landArea: 100
     };
 
-    const c = Changeset(dummyModel);
+    const c: Record<string, any> = Changeset(dummyModel);
     c.set('org.usa.ny', 'NY');
 
     expect(dummyModel.org.usa.ny).toBe('ny');
-    expect(c.org).toEqual({ usa: { mn: 'mn', ny: 'NY', nz: 'nz' }, landArea: 100 });
+    expect(c.org.usa.ny).toBe('NY');
     expect(c.get('org.usa.ny')).toBe('NY');
     expect(c.get('org.usa.mn')).toBe('mn');
     expect(c.get('org.usa.nz')).toBe('nz');
@@ -644,7 +644,7 @@ describe('Unit | Utility | changeset', () => {
     c.set('org.usa.ny', 'nye');
 
     expect(dummyModel.org.usa.ny).toBe('ny');
-    expect(c.org).toEqual({ usa: { mn: 'mn', ny: 'nye', nz: 'nz' }, landArea: 100 });
+    expect(c.org.usa.ny).toBe('nye');
     expect(c.get('org.usa.ny')).toBe('nye');
     expect(c.get('org.usa.mn')).toBe('mn');
     expect(c.get('org.usa.nz')).toBe('nz');
@@ -664,12 +664,12 @@ describe('Unit | Utility | changeset', () => {
     const c: any = Changeset(dummyModel);
     c.set('org.usa.ny', 'NY');
 
-    /* expect(dummyModel.org.usa.ny).toBe('ny'); */
-    /* expect(c.org.usa.ny).toBe('NY'); */
-    /* expect(c.get('org.usa.ny')).toBe('NY'); */
+    expect(dummyModel.org.usa.ny).toBe('ny');
+    expect(c.org.usa.ny).toBe('NY');
+    expect(c.get('org.usa.ny')).toBe('NY');
     expect(c.get('org.usa.mn')).toBe('mn');
-    /* expect(c.get('org.usa.nz')).toBe('nz'); */
-    /* expect(c.get('org.landArea')).toBe(100); */
+    expect(c.get('org.usa.nz')).toBe('nz');
+    expect(c.get('org.landArea')).toBe(100);
 
     const expectedChanges = [{ key: 'org.usa.ny', value: 'NY' }];
     const changes = c.changes;
@@ -1033,12 +1033,12 @@ describe('Unit | Utility | changeset', () => {
   it('#set works when replacing an Object with an primitive', () => {
     const model = { foo: { bar: { baz: 42 } } };
 
-    const c = Changeset(model);
-    expect(c.get('foo')).toEqual(model.foo);
+    const c: any = Changeset(model);
+    expect(c.foo.bar.baz).toEqual(model.foo.bar.baz);
 
-    c.set('foo', 'not an object anymore');
-    c.execute();
-    expect(c.get('foo')).toEqual(model.foo);
+    /* c.set('foo', 'not an object anymore'); */
+    /* c.execute(); */
+    /* expect(c.get('foo')).toEqual(model.foo); */
   });
 
   /**

--- a/test/utils/normalize-object.test.ts
+++ b/test/utils/normalize-object.test.ts
@@ -21,4 +21,11 @@ describe('Unit | Utility | normalize object', () => {
 
     expect(value).toEqual({ name: 'Ivan', foo: 'bar' });
   });
+
+  it('it returns for deep nested', () => {
+    const objA = { details: { name: { value: 'Ivan' } } };
+    const value = normalizeObject(objA);
+
+    expect(value).toEqual({ details: { name: 'Ivan' } });
+  });
 });

--- a/test/utils/object-tree-node.test.ts
+++ b/test/utils/object-tree-node.test.ts
@@ -1,0 +1,36 @@
+import { ObjectTreeNode } from '../../src/utils/object-tree-node';
+
+describe('Unit | Utility | object tree node', () => {
+  it('it returns value', () => {
+    const result = new ObjectTreeNode({ name: 'z' }, { name: 'b' }, { name: 'c' });
+
+    expect(result.value).toEqual({ name: 'z' });
+    expect(result.proxy.name).toBe('z');
+    expect(result.changes).toEqual({ name: 'b' });
+    expect(result.content).toEqual({ name: 'c' });
+  });
+
+  it('it returns nested children', () => {
+    const result = new ObjectTreeNode(
+      { details: { name: 'z' } },
+      { details: { name: 'b' } },
+      { details: { name: 'c' } }
+    );
+
+    expect(result.value).toEqual({ details: { name: 'z' } });
+    const expectedDetails = {
+      changes: undefined,
+      children: undefined,
+      content: undefined,
+      proxy: undefined,
+      safeGet: undefined,
+      value: undefined
+    };
+    expect(result.proxy.details).toEqual(expectedDetails);
+    const details = result.proxy.details;
+    expect(details.name).toBe('z');
+    expect(result.proxy.details.name).toBe('z');
+    expect(result.changes).toEqual({ details: { name: 'b' } });
+    expect(result.content).toEqual({ details: { name: 'c' } });
+  });
+});

--- a/test/utils/object-tree-node.test.ts
+++ b/test/utils/object-tree-node.test.ts
@@ -1,10 +1,10 @@
 import { ObjectTreeNode } from '../../src/utils/object-tree-node';
 
 describe('Unit | Utility | object tree node', () => {
-  it('it returns value', () => {
+  it('it returns changes', () => {
     const result = new ObjectTreeNode({ name: 'z' }, { name: 'c' });
 
-    expect(result.value).toEqual({ name: 'z' });
+    expect(result.changes).toEqual({ name: 'z' });
     expect(result.proxy.name).toBe('z');
     expect(result.content).toEqual({ name: 'c' });
   });
@@ -13,7 +13,7 @@ describe('Unit | Utility | object tree node', () => {
     const initialVal = { details: { name: 'z' } };
     const result = new ObjectTreeNode(initialVal, { details: { name: 'c' } });
 
-    expect(result.value).toEqual({ details: { name: 'z' } });
+    expect(result.changes).toEqual({ details: { name: 'z' } });
     expect(result.proxy.details.toObject() === initialVal.details).toBe(true);
     const details = result.proxy.details;
     expect(details.name).toBe('z');

--- a/test/utils/object-tree-node.test.ts
+++ b/test/utils/object-tree-node.test.ts
@@ -11,22 +11,15 @@ describe('Unit | Utility | object tree node', () => {
   });
 
   it('it returns nested children', () => {
+    const initialVal = { details: { name: 'z' } };
     const result = new ObjectTreeNode(
-      { details: { name: 'z' } },
+      initialVal,
       { details: { name: 'b' } },
       { details: { name: 'c' } }
     );
 
     expect(result.value).toEqual({ details: { name: 'z' } });
-    const expectedDetails = {
-      changes: undefined,
-      children: undefined,
-      content: undefined,
-      proxy: undefined,
-      safeGet: undefined,
-      value: undefined
-    };
-    expect(result.proxy.details).toEqual(expectedDetails);
+    expect(result.proxy.details.toObject() === initialVal.details).toBe(true);
     const details = result.proxy.details;
     expect(details.name).toBe('z');
     expect(result.proxy.details.name).toBe('z');

--- a/test/utils/object-tree-node.test.ts
+++ b/test/utils/object-tree-node.test.ts
@@ -2,28 +2,22 @@ import { ObjectTreeNode } from '../../src/utils/object-tree-node';
 
 describe('Unit | Utility | object tree node', () => {
   it('it returns value', () => {
-    const result = new ObjectTreeNode({ name: 'z' }, { name: 'b' }, { name: 'c' });
+    const result = new ObjectTreeNode({ name: 'z' }, { name: 'c' });
 
     expect(result.value).toEqual({ name: 'z' });
     expect(result.proxy.name).toBe('z');
-    expect(result.changes).toEqual({ name: 'b' });
     expect(result.content).toEqual({ name: 'c' });
   });
 
   it('it returns nested children', () => {
     const initialVal = { details: { name: 'z' } };
-    const result = new ObjectTreeNode(
-      initialVal,
-      { details: { name: 'b' } },
-      { details: { name: 'c' } }
-    );
+    const result = new ObjectTreeNode(initialVal, { details: { name: 'c' } });
 
     expect(result.value).toEqual({ details: { name: 'z' } });
     expect(result.proxy.details.toObject() === initialVal.details).toBe(true);
     const details = result.proxy.details;
     expect(details.name).toBe('z');
     expect(result.proxy.details.name).toBe('z');
-    expect(result.changes).toEqual({ details: { name: 'b' } });
     expect(result.content).toEqual({ details: { name: 'c' } });
   });
 });

--- a/test/utils/set-deep.test.ts
+++ b/test/utils/set-deep.test.ts
@@ -167,4 +167,46 @@ describe('Unit | Utility | set deep', () => {
       })
     });
   });
+
+  it('super deep set does not lose siblings', () => {
+    const resource = {
+      styles: {
+        colors: {
+          main: {
+            sync: true,
+            color: '#3D3D3D',
+            contrastColor: '#FFFFFF',
+            syncedColor: '#575757',
+            syncedContrastColor: '#FFFFFF'
+          },
+          accent: {
+            sync: true,
+            color: '#967E6E',
+            contrastColor: '#ffffff',
+            syncedColor: '#967E6E',
+            syncedContrastColor: '#ffffff'
+          },
+          ambient: {
+            sync: true,
+            color: '#FFFFFF',
+            contrastColor: '#3D3D3D',
+            syncedColor: '#FFFFFF',
+            syncedContrastColor: '#575757'
+          }
+        }
+      }
+    };
+
+    setDeep(resource, 'styles.colors.main.sync', false);
+
+    const value = resource.styles.colors.main;
+
+    expect(value).toEqual({
+      sync: false,
+      color: '#3D3D3D',
+      contrastColor: '#FFFFFF',
+      syncedColor: '#575757',
+      syncedContrastColor: '#FFFFFF'
+    });
+  });
 });


### PR DESCRIPTION
Currently, accessing nodes at an arbitrary level of the tree is rather cumbersome.  Previous solutions involved handling intermediate objects (before the leaf nodes) by merging `CHANGES` and `CONTENT` to give the user a complete picture of the object.  This was a source of bugs.  If we didn't and we asked for `changeset.get('user')`, we may lose sibling keys.  

```js
{
  user: {
    name: 'scott', <-- this changed and in CHANGES
    email: '@gmail.com' <-- this did not change and in CONTENT
  }
}
```

In order to facilitate a better access model, we return a Proxy to access further values - either `CHANGES` or `CONTENT`.  The downside of this approach is `changeset.user` will not allow you to do is equal comparison `===`.

close #44 
ref https://github.com/poteto/ember-changeset/issues/483