### PR TITLE
Ember requires us to add ProxyHandler#set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -928,16 +928,12 @@ export class BufferedChangeset implements IChangeset {
     }
   }
 
-  set<T>(
-    key: string,
-    value: T
-  ): void | Promise<ValidationResult | T | IErr<T>> | T | IErr<T> | ValidationResult {
+  set<T>(key: string, value: T): void {
     if (this.hasOwnProperty(key) || keyInObject(this, key)) {
       this[key] = value;
-      return;
+    } else {
+      this.setUnknownProperty(key, value);
     }
-
-    this.setUnknownProperty(key, value);
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,10 @@
 export interface ProxyHandler {
-  changes: unknown;
+  changes: Record<string, any>;
   content: unknown;
   proxy: any;
   children: Record<string, any>;
   safeGet: Function;
+  [key: string]: any;
 }
 
 export type Config = {

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -7,7 +7,7 @@ const objectProxyHandler = {
    * Priority of access - changes, content, then check node
    * @property get
    */
-  get(node: Record<string, any>, key: string) {
+  get(node: ProxyHandler, key: string): any {
     if (typeof key === 'symbol') {
       return;
     }
@@ -40,7 +40,7 @@ const objectProxyHandler = {
       return childValue;
     } else {
       if (
-        node.content.hasOwnProperty(key) ||
+        (node.content as object).hasOwnProperty(key) ||
         typeof node.safeGet(node.content, key) === 'function'
       ) {
         return node.safeGet(node.content, key);
@@ -52,20 +52,20 @@ const objectProxyHandler = {
     }
   },
 
-  ownKeys(node: Record<string, any>) {
+  ownKeys(node: ProxyHandler): any {
     return Reflect.ownKeys(node.changes);
   },
 
-  getOwnPropertyDescriptor(node: Record<string, any>, prop: string) {
+  getOwnPropertyDescriptor(node: ProxyHandler, prop: string): any {
     return Reflect.getOwnPropertyDescriptor(node.changes, prop);
   },
 
-  has(node: Record<string, any>, prop: string) {
+  has(node: ProxyHandler, prop: string): any {
     return Reflect.has(node.changes, prop);
   },
 
-  set() {
-    return false;
+  set(node: ProxyHandler, key: string, value: unknown): any {
+    return Reflect.set(node.changes, key, value);
   }
 };
 
@@ -74,13 +74,13 @@ function defaultSafeGet(obj: Record<string, any>, key: string) {
 }
 
 class ObjectTreeNode implements ProxyHandler {
-  changes: unknown;
+  changes: Record<string, any>;
   content: Content;
   proxy: any;
   children: Record<string, any>;
 
   constructor(
-    changes: unknown = {},
+    changes: Record<string, any> = {},
     content: Content = {},
     public safeGet: Function = defaultSafeGet
   ) {
@@ -90,7 +90,7 @@ class ObjectTreeNode implements ProxyHandler {
     this.children = Object.create(null);
   }
 
-  toObject() {
+  toObject(): Record<string, any> {
     return this.changes;
   }
 }

--- a/test/utils/object-tree-node.test.ts
+++ b/test/utils/object-tree-node.test.ts
@@ -20,4 +20,12 @@ describe('Unit | Utility | object tree node', () => {
     expect(result.proxy.details.name).toBe('z');
     expect(result.content).toEqual({ details: { name: 'c' } });
   });
+
+  it('can set nested value on returned proxy', () => {
+    const initialVal = { details: { name: 'z' } };
+    const result = new ObjectTreeNode(initialVal, { details: { name: 'c' } });
+
+    result.proxy.details['name'] = 'bla bla';
+    expect(result.proxy.details.name).toBe('bla bla');
+  });
 });

--- a/test/utils/object-tree-node.test.ts
+++ b/test/utils/object-tree-node.test.ts
@@ -22,10 +22,13 @@ describe('Unit | Utility | object tree node', () => {
   });
 
   it('can set nested value on returned proxy', () => {
-    const initialVal = { details: { name: 'z' } };
+    const initialVal = { details: { name: 'z', email: '@' } };
     const result = new ObjectTreeNode(initialVal, { details: { name: 'c' } });
 
     result.proxy.details['name'] = 'bla bla';
     expect(result.proxy.details.name).toBe('bla bla');
+    expect(result.proxy.details.email).toBe('@');
+    expect(result.changes.details.name).toBe('bla bla');
+    expect(result.content.details.name).toBe('c');
   });
 });


### PR DESCRIPTION
with `Ember.set(node, 'user.email')`, Ember will break up the key and set the value on each successive node down the tree.  As a result of us returning a Proxy at each level, we need to allow a setter at each level.