### PR TITLE
Validate changeset getter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -794,6 +794,11 @@ export class BufferedChangeset implements IChangeset {
     let errors: Errors<any> = this[ERRORS];
     let content: Content = this[CONTENT];
 
+    // Derived property, i.e. property defined in the changeset itself
+    if (Object.prototype.hasOwnProperty.apply(this, [key])) {
+      return this[key];
+    }
+
     if (errors.hasOwnProperty(key)) {
       let e: Err = errors[key];
       return e.value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -791,17 +791,11 @@ export class BufferedChangeset implements IChangeset {
    */
   _valueFor(key: string): any {
     let changes: Changes = this[CHANGES];
-    let errors: Errors<any> = this[ERRORS];
     let content: Content = this[CONTENT];
 
     // Derived property, i.e. property defined in the changeset itself
     if (Object.prototype.hasOwnProperty.apply(this, [key])) {
       return this[key];
-    }
-
-    if (errors.hasOwnProperty(key)) {
-      let e: Err = errors[key];
-      return e.value;
     }
 
     // 'person'


### PR DESCRIPTION
If we need to validate based on derived property, not the raw changes
the only place where we can put a getter to calculate the value of that
property is the changeset itself as it buffers all changes.

This PR is an attempt to make it work.