### PR TITLE
Add user provided changesetKeys to 4th constructor arg to Changeset

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: 
 ```
 
 - `validationMap` - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
-    note: `validationMap` might not be inclusive of all keys that can be set on an object
+    note: `validationMap` might not be inclusive of all keys that can be set on an object.
 - `changesetKeys` - will ensure your changeset and related `isDirty` state is contained to a specific enum of keys.  If a key that is not in `changesetKeys` is set on the changeset, it will not dirty the changeset.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: 
 ```
 
 - `validationMap` - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
-- `validationKeys` will ensure your changeset and related `isDirty` state is contained to a specific enum of keys.  If a key that is not in `validationKeys` is set on the changeset, it will not dirty the changeset.
+    note: `validationMap` might not be inclusive of all keys that can be set on an object
+- `changesetKeys` - will ensure your changeset and related `isDirty` state is contained to a specific enum of keys.  If a key that is not in `changesetKeys` is set on the changeset, it will not dirty the changeset.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ In the above example, when the input changes, only the changeset's internal valu
 
 On rollback, all changes are dropped and the underlying Object is left untouched.
 
+## Full API
+
+```js
+Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: boolean, validationKeys: string[] });
+```
+
+- `validationKeys` will contain your changeset and related `isDirty` state to a specific enum of keys.  If a key that is not in `validationKeys` is set on the changeset, it will not dirty the changeset.
+
 ## Examples
 
 - [`ember-changeset`](https://github.com/poteto/ember-changeset)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 ## Full API
 
 ```js
-Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: boolean, validationKeys: string[] });
+Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: boolean, changesetKeys: string[] });
 ```
 
 - `validationMap` - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: boolean, changesetKeys: string[] });
 ```
 
+- `model` (required)
+
 - `validationFunc` (optional) - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
 
 - `validationMap` (optional) - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: 
 ```
 
 - `validationMap` - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
+
     note: `validationMap` might not be inclusive of all keys that can be set on an object.
+
 - `changesetKeys` - will ensure your changeset and related `isDirty` state is contained to a specific enum of keys.  If a key that is not in `changesetKeys` is set on the changeset, it will not dirty the changeset.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: boolean, validationKeys: string[] });
 ```
 
+- `validationMap` - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
 - `validationKeys` will contain your changeset and related `isDirty` state to a specific enum of keys.  If a key that is not in `validationKeys` is set on the changeset, it will not dirty the changeset.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: boolean, changesetKeys: string[] });
 ```
 
-- `validationMap` - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
+- `validationFunc` (optional) - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
 
-    note: `validationMap` might not be inclusive of all keys that can be set on an object.
+- `validationMap` (optional) - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
 
-- `changesetKeys` - will ensure your changeset and related `isDirty` state is contained to a specific enum of keys.  If a key that is not in `changesetKeys` is set on the changeset, it will not dirty the changeset.
+    > note: `validationMap` might not be inclusive of all keys that can be set on an object.
+
+- `changesetKeys` (optional) - will ensure your changeset and related `isDirty` state is contained to a specific enum of keys.  If a key that is not in `changesetKeys` is set on the changeset, it will not dirty the changeset.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: 
 ```
 
 - `validationMap` - see [ember-changeset-validations](https://github.com/poteto/ember-changeset-validations#usage) for usage.
-- `validationKeys` will contain your changeset and related `isDirty` state to a specific enum of keys.  If a key that is not in `validationKeys` is set on the changeset, it will not dirty the changeset.
+- `validationKeys` will ensure your changeset and related `isDirty` state is contained to a specific enum of keys.  If a key that is not in `validationKeys` is set on the changeset, it will not dirty the changeset.
 
 ## Examples
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,9 +227,9 @@ export class BufferedChangeset implements IChangeset {
    */
   get isPristine() {
     let validationKeys = Object.keys(this[CHANGES]);
-    const userValidationKeys: string[] | undefined = this[OPTIONS].validationKeys;
-    if (Array.isArray(userValidationKeys) && userValidationKeys.length) {
-      validationKeys = validationKeys.filter(k => userValidationKeys.includes(k));
+    const userChangesetKeys: string[] | undefined = this[OPTIONS].changesetKeys;
+    if (Array.isArray(userChangesetKeys) && userChangesetKeys.length) {
+      validationKeys = validationKeys.filter(k => userChangesetKeys.includes(k));
     }
 
     if (validationKeys.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export class BufferedChangeset implements IChangeset {
   [CHANGES]: Changes;
   [ERRORS]: Errors<any>;
   [VALIDATOR]: ValidatorAction;
-  [OPTIONS]: {};
+  [OPTIONS]: Config;
   [RUNNING_VALIDATIONS]: {};
 
   __changeset__ = CHANGESET;
@@ -226,8 +226,13 @@ export class BufferedChangeset implements IChangeset {
    * @type {Boolean}
    */
   get isPristine() {
-    const isEmpty = Object.keys(this[CHANGES]).length === 0;
-    if (isEmpty) {
+    let validationKeys = Object.keys(this[CHANGES]);
+    const userValidationKeys: string[] | undefined = this[OPTIONS].validationKeys;
+    if (Array.isArray(userValidationKeys) && userValidationKeys.length) {
+      validationKeys = validationKeys.filter(k => userValidationKeys.includes(k));
+    }
+
+    if (validationKeys.length === 0) {
       return true;
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface ProxyHandler {
 
 export type Config = {
   skipValidate?: boolean;
+  validationKeys?: string[];
 };
 
 export type ValidationOk = boolean | [boolean];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,7 @@ export interface ProxyHandler {
 
 export type Config = {
   skipValidate?: boolean;
-  validationKeys?: string[];
+  changesetKeys?: string[];
 };
 
 export type ValidationOk = boolean | [boolean];

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -63,6 +63,9 @@ const objectProxyHandler = {
   },
 
   set(node: ProxyHandler, key: string, value: unknown): any {
+    if (key.startsWith('_')) {
+      return Reflect.set(node, key, value);
+    }
     return Reflect.set(node.changes, key, new Change(value));
   }
 };

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -63,6 +63,7 @@ const objectProxyHandler = {
   },
 
   set(node: ProxyHandler, key: string, value: unknown): any {
+    // dont want to set private properties on changes (usually found on outside actors)
     if (key.startsWith('_')) {
       return Reflect.set(node, key, value);
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -285,6 +285,32 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyChangeset.get('isPristine')).toBeTruthy();
   });
 
+  it('isPristine returns false if changes not in user provided validationKeys', () => {
+    dummyModel.name = 'Bobby';
+    dummyModel.thing = 123;
+    dummyModel.nothing = null;
+    const validationKeys = ['name'];
+    const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations), null, {
+      validationKeys
+    });
+    dummyChangeset.set('nothing', 'something');
+
+    expect(dummyChangeset.get('isPristine')).toBe(true);
+  });
+
+  it('isPristine returns false if set a key in validationKeys', () => {
+    dummyModel.name = 'Bobby';
+    dummyModel.thing = 123;
+    dummyModel.nothing = null;
+    const validationKeys = ['razataz'];
+    const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations), null, {
+      validationKeys
+    });
+    dummyChangeset.set('razataz', 'boom');
+
+    expect(dummyChangeset.get('isPristine')).toBe(false);
+  });
+
   /**
    * #isDirty
    */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -285,26 +285,26 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyChangeset.get('isPristine')).toBeTruthy();
   });
 
-  it('isPristine returns false if changes not in user provided validationKeys', () => {
+  it('isPristine returns false if changes not in user provided changesetKeys', () => {
     dummyModel.name = 'Bobby';
     dummyModel.thing = 123;
     dummyModel.nothing = null;
-    const validationKeys = ['name'];
+    const changesetKeys = ['name'];
     const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations), null, {
-      validationKeys
+      changesetKeys
     });
     dummyChangeset.set('nothing', 'something');
 
     expect(dummyChangeset.get('isPristine')).toBe(true);
   });
 
-  it('isPristine returns false if set a key in validationKeys', () => {
+  it('isPristine returns false if set a key in changesetKeys', () => {
     dummyModel.name = 'Bobby';
     dummyModel.thing = 123;
     dummyModel.nothing = null;
-    const validationKeys = ['razataz'];
+    const changesetKeys = ['razataz'];
     const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations), null, {
-      validationKeys
+      changesetKeys
     });
     dummyChangeset.set('razataz', 'boom');
 


### PR DESCRIPTION
```
const changeset = Changeset(model, lookupValidator(validations), null, { changesetKeys: ['name', 'email'] };
```

ref https://github.com/poteto/ember-changeset/issues/485

Tests to re-enable - https://github.com/poteto/ember-changeset/blob/b7a244b05b73698a60bb2eb552336934de179983/tests/integration/main-test.js#L188