### PR TITLE
Protect safeGet from undefined values

### DIFF
--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -26,20 +26,22 @@ const objectProxyHandler = {
     if (isObject(childValue)) {
       let childNode: ProxyHandler | undefined = node.children[key];
 
-      if (childNode === undefined) {
+      if (childNode === undefined && node.content) {
         let childContent = node.safeGet(node.content, key);
         // cache it
         childNode = node.children[key] = new ObjectTreeNode(childValue, childContent, node.safeGet);
       }
 
       // return proxy if object so we can trap further access to changes or content
-      return childNode ? childNode.proxy : undefined;
+      if (childNode) {
+        return childNode.proxy;
+      }
     }
 
     if (typeof childValue !== 'undefined') {
       // primitive
       return childValue;
-    } else {
+    } else if (node.content) {
       const nodeContent = node.content;
       if (node.safeGet(nodeContent, key) || typeof node.safeGet(nodeContent, key) === 'function') {
         return node.safeGet(nodeContent, key);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1854,6 +1854,16 @@ describe('Unit | Utility | changeset', () => {
     expect(get(dummyChangeset, 'errors.length')).toBe(2);
   });
 
+  it('#validate/1 validates a property with no validation', async () => {
+    dummyModel.org = {};
+    let dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations), dummyValidations);
+
+    await dummyChangeset.validate('org');
+    expect(get(dummyChangeset, 'error.org')).toEqual(undefined);
+    expect(dummyChangeset.changes).toEqual([]);
+    expect(get(dummyChangeset, 'errors.length')).toBe(0);
+  });
+
   it('#validate works correctly with changeset values', async () => {
     dummyModel = {
       ...dummyModel,


### PR DESCRIPTION
close #62 

Ember.get will fail if the 1st arg is undefined