### PR TITLE
Add overridable isObject function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -549,8 +549,7 @@ export class BufferedChangeset implements IChangeset {
     let errors: Errors<any> = this[ERRORS];
     // @tracked
     this[ERRORS] = this.setDeep(errors, key, newError, {
-      safeSet: this.safeSet,
-      isObject: this.isObject
+      safeSet: this.safeSet
     });
 
     // Return passed-in `error`.
@@ -578,8 +577,7 @@ export class BufferedChangeset implements IChangeset {
     let newError = new Err(value, validation);
     // @tracked
     this[ERRORS] = this.setDeep(errors, key as string, newError, {
-      safeSet: this.safeSet,
-      isObject: this.isObject
+      safeSet: this.safeSet
     });
 
     return { value, validation };
@@ -781,8 +779,7 @@ export class BufferedChangeset implements IChangeset {
     if (oldValue !== value) {
       // @tracked
       let result: Changes = this.setDeep(changes, key, new Change(value), {
-        safeSet: this.safeSet,
-        isObject: this.isObject
+        safeSet: this.safeSet
       });
 
       const content: Content = this[CONTENT];
@@ -811,7 +808,7 @@ export class BufferedChangeset implements IChangeset {
       return;
     }
 
-    this.setDeep(running, key, value ? count + 1 : count - 1, { isObject: this.isObject });
+    this.setDeep(running, key, value ? count + 1 : count - 1);
   }
 
   /**
@@ -938,8 +935,7 @@ export class BufferedChangeset implements IChangeset {
             key,
             {},
             {
-              safeSet: this.safeSet,
-              isObject: this.isObject
+              safeSet: this.safeSet
             }
           ),
           key

--- a/src/index.ts
+++ b/src/index.ts
@@ -887,9 +887,9 @@ export class BufferedChangeset implements IChangeset {
 
       // 'user.name'
       const normalizedBaseChanges = normalizeObject(baseChanges, this.isObject);
-      if (this.isObject(normalizedBaseChanges)) {
+      if (isObject(normalizedBaseChanges)) {
         const result = this.getDeep(normalizedBaseChanges, remaining.join('.'));
-        if (this.isObject(result)) {
+        if (isObject(result)) {
           if (result instanceof Change) {
             return normalizeEmptyObject(result.value, this.isObject);
           }
@@ -919,7 +919,7 @@ export class BufferedChangeset implements IChangeset {
       return this[key];
     } else if (typeof this[baseKey] !== 'undefined') {
       const v: unknown = this[baseKey];
-      if (this.isObject(v)) {
+      if (isObject(v)) {
         const result = this.getDeep(v as Record<string, any>, remaining.join('.'));
         return result;
       }
@@ -928,7 +928,7 @@ export class BufferedChangeset implements IChangeset {
     // finally return on underlying object or proxy to further access nested keys
     const subContent = this.getDeep(content, key);
     let subChanges = this.getDeep(changes, key);
-    if (this.isObject(subContent)) {
+    if (isObject(subContent)) {
       if (!subChanges) {
         // if no changes, we need to add the path to the existing changes (mutate)
         // so further access to nested keys works

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ export interface ProxyHandler {
   proxy: any;
   children: Record<string, any>;
   safeGet: Function;
-  unwrap: Function,
+  unwrap: Function;
   [key: string]: any;
 }
 
@@ -105,6 +105,8 @@ export type PrepareChangesFn = (obj: { [s: string]: any }) => { [s: string]: any
 
 export interface ChangesetDef {
   __changeset__: string;
+
+  isObject: Function;
 
   _content: object;
   _changes: Changes;

--- a/src/utils/has-changes.ts
+++ b/src/utils/has-changes.ts
@@ -1,14 +1,13 @@
-import isObject from './is-object';
 import Change from '../-private/change';
 
-export function hasChanges(changes: Record<string, any>): boolean {
+export function hasChanges(changes: Record<string, any>, isObject: Function): boolean {
   for (let key in changes) {
     if (changes[key] instanceof Change) {
       return true;
     }
 
     if (isObject(changes[key])) {
-      const isTruthy = hasChanges(changes[key]);
+      const isTruthy = hasChanges(changes[key], isObject);
       if (isTruthy) {
         return isTruthy;
       }

--- a/src/utils/mark-undefined-leaf-keys.ts
+++ b/src/utils/mark-undefined-leaf-keys.ts
@@ -1,28 +1,28 @@
 import { Content } from '../types';
-import isObject from './is-object';
 import Change from '../-private/change';
 import Empty from '../-private/empty';
 
 interface Options {
   safeGet: any;
+  isObject: Function;
 }
 
 function markEmpty(changesNode: Record<string, any>, contentNode: unknown, options: Options) {
-  if (isObject(changesNode) && isObject(contentNode)) {
+  if (options.isObject(changesNode) && options.isObject(contentNode)) {
     // first iterate changes and see if content has keys that aren't in there
     for (const key in changesNode) {
       const subChanges = changesNode[key];
       const nodeInContent = options.safeGet(contentNode, key);
-      if (isObject(nodeInContent)) {
+      if (options.isObject(nodeInContent)) {
         for (let contentKey in nodeInContent) {
-          if (isObject(subChanges) && !subChanges[contentKey]) {
+          if (options.isObject(subChanges) && !subChanges[contentKey]) {
             // mark empty if exists on content but not on changes
             subChanges[contentKey] = new Empty();
           }
         }
       }
 
-      if (isObject(subChanges)) {
+      if (options.isObject(subChanges)) {
         markEmpty(subChanges, options.safeGet(contentNode, key), options);
       }
     }
@@ -50,7 +50,7 @@ function markEmpty(changesNode: Record<string, any>, contentNode: unknown, optio
 export function markUndefinedLeafKeys<T>(changes: T, content: Content, options: Options): T {
   for (let key in changes) {
     const changesNode = changes[key];
-    if (isObject(changesNode) && isObject(content)) {
+    if (options.isObject(changesNode) && options.isObject(content)) {
       if (changesNode instanceof Change) {
         // here we need to start checking for empty keys
         markEmpty(changesNode.value, options.safeGet(content, key), options);

--- a/src/utils/merge-deep.ts
+++ b/src/utils/merge-deep.ts
@@ -1,9 +1,11 @@
 import Change from '../-private/change';
 import normalizeObject from './normalize-object';
+import isVCObject from './is-object';
 
 interface Options {
-  safeGet: any;
-  safeSet: any;
+  safeGet?: any;
+  safeSet?: any;
+  isObject: Function;
 }
 
 function isNonNullObject(value: any): boolean {
@@ -118,7 +120,7 @@ function mergeTargetAndSource(target: any, source: any, options: Options): any {
         return options.safeSet(target, key, next.value);
       }
 
-      return options.safeSet(target, key, normalizeObject(next));
+      return options.safeSet(target, key, normalizeObject(next, options.isObject));
     }
   });
 
@@ -137,7 +139,7 @@ function mergeTargetAndSource(target: any, source: any, options: Options): any {
 export default function mergeDeep(
   target: any,
   source: any,
-  options: Options = { safeGet: undefined, safeSet: undefined }
+  options: Options = { safeGet: undefined, safeSet: undefined, isObject: isVCObject }
 ): object | [any] {
   options.safeGet =
     options.safeGet ||
@@ -149,6 +151,7 @@ export default function mergeDeep(
     function(obj: any, key: string, value: unknown): any {
       return (obj[key] = value);
     };
+
   let sourceIsArray = Array.isArray(source);
   let targetIsArray = Array.isArray(target);
   let sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;

--- a/src/utils/normalize-object.ts
+++ b/src/utils/normalize-object.ts
@@ -1,6 +1,6 @@
 import Change from '../-private/change';
 import Empty from '../-private/empty';
-import isObject from './is-object';
+import isVCObject from './is-object';
 
 /**
  * traverse through target and unset `value` from leaf key so can access normally
@@ -23,7 +23,10 @@ import isObject from './is-object';
  * @param {Object} target
  * @return {Object}
  */
-export default function normalizeObject<T extends { [key: string]: any }>(target: T): T {
+export default function normalizeObject<T extends { [key: string]: any }>(
+  target: T,
+  isObject: Function = isVCObject
+): T {
   if (!target || !isObject(target)) {
     return target;
   }
@@ -40,7 +43,7 @@ export default function normalizeObject<T extends { [key: string]: any }>(target
       if (Object.prototype.hasOwnProperty.call(next, 'value') && next instanceof Change) {
         obj[key] = next.value;
       } else {
-        obj[key] = normalizeObject(next);
+        obj[key] = normalizeObject(next, isObject);
       }
     }
   }
@@ -69,7 +72,10 @@ export default function normalizeObject<T extends { [key: string]: any }>(target
  * @param {Object} target
  * @return {Object | string}
  */
-export function normalizeEmptyObject<T extends { [key: string]: any }>(target: T): T | undefined {
+export function normalizeEmptyObject<T extends { [key: string]: any }>(
+  target: T,
+  isObject: Function
+): T | undefined {
   if (!target || !isObject(target)) {
     return target;
   }
@@ -86,7 +92,7 @@ export function normalizeEmptyObject<T extends { [key: string]: any }>(target: T
       if (Object.prototype.hasOwnProperty.call(next, 'value') && next instanceof Empty) {
         obj[key] = undefined;
       } else {
-        obj[key] = normalizeEmptyObject(next);
+        obj[key] = normalizeEmptyObject(next, isObject);
       }
     }
   }

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -1,8 +1,9 @@
 import Change from '../-private/change';
-import isObject from './is-object';
+import isVCObject from './is-object';
 
 interface Options {
-  safeSet: any;
+  safeSet?: any;
+  isObject: Function;
 }
 
 function split(path: string): string[] {
@@ -39,7 +40,7 @@ export default function setDeep(
   target: any,
   path: string,
   value: unknown,
-  options: Options = { safeSet: undefined }
+  options: Options = { safeSet: undefined, isObject: isVCObject }
 ): any {
   const keys = split(path).filter(isValidKey);
   // We will mutate target and through complex reference, we will mutate the orig
@@ -59,11 +60,11 @@ export default function setDeep(
   for (let i = 0; i < keys.length; i++) {
     let prop = keys[i];
 
-    const isObj = isObject(target[prop]);
+    const isObj = options.isObject(target[prop]);
     if (!isObj) {
       options.safeSet(target, prop, {});
     } else if (isObj && target[prop] instanceof Change) {
-      if (isObject(target[prop].value)) {
+      if (options.isObject(target[prop].value)) {
         // if an object, we don't want to lose sibling keys
         const siblings = findSiblings(target[prop].value, keys);
         const resolvedValue = value instanceof Change ? value.value : value;

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -1,9 +1,8 @@
 import Change from '../-private/change';
-import isVCObject from './is-object';
+import isObject from './is-object';
 
 interface Options {
-  safeSet?: any;
-  isObject: Function;
+  safeSet: any;
 }
 
 function split(path: string): string[] {
@@ -40,7 +39,7 @@ export default function setDeep(
   target: any,
   path: string,
   value: unknown,
-  options: Options = { safeSet: undefined, isObject: isVCObject }
+  options: Options = { safeSet: undefined }
 ): any {
   const keys = split(path).filter(isValidKey);
   // We will mutate target and through complex reference, we will mutate the orig
@@ -60,11 +59,11 @@ export default function setDeep(
   for (let i = 0; i < keys.length; i++) {
     let prop = keys[i];
 
-    const isObj = options.isObject(target[prop]);
+    const isObj = isObject(target[prop]);
     if (!isObj) {
       options.safeSet(target, prop, {});
     } else if (isObj && target[prop] instanceof Change) {
-      if (options.isObject(target[prop].value)) {
+      if (isObject(target[prop].value)) {
         // if an object, we don't want to lose sibling keys
         const siblings = findSiblings(target[prop].value, keys);
         const resolvedValue = value instanceof Change ? value.value : value;

--- a/test/utils/has-changes.test.ts
+++ b/test/utils/has-changes.test.ts
@@ -1,38 +1,39 @@
 import { hasChanges } from '../../src/utils/has-changes';
 import Change from '../../src/-private/change';
+import isObject from '../../src/utils/is-object';
 
 describe('Unit | Utility | has changes', () => {
   it('it returns false', () => {
     const objA = new Change({ value: 'Ivan' });
-    const value = hasChanges(objA);
+    const value = hasChanges(objA, isObject);
 
     expect(value).toBe(false);
   });
 
   it('it returns true', () => {
     const objA = { name: new Change({ value: 'Ivan' }) };
-    const value = hasChanges(objA);
+    const value = hasChanges(objA, isObject);
 
     expect(value).toEqual(true);
   });
 
   it('it returns multiple values from nested', () => {
     const objA = { name: { value: 'Ivan' }, foo: new Change({ value: 'bar' }) };
-    const value = hasChanges(objA);
+    const value = hasChanges(objA, isObject);
 
     expect(value).toEqual(true);
   });
 
   it('it returns for deep nested', () => {
     const objA = { details: { name: new Change({ value: 'Ivan' }) } };
-    const value = hasChanges(objA);
+    const value = hasChanges(objA, isObject);
 
     expect(value).toEqual(true);
   });
 
   it('it returns false for no changes', () => {
     const objA = { details: { name: { value: 'Ivan' } } };
-    const value = hasChanges(objA);
+    const value = hasChanges(objA, isObject);
 
     expect(value).toEqual(false);
   });

--- a/test/utils/mark-undefined-leaf-keys.test.ts
+++ b/test/utils/mark-undefined-leaf-keys.test.ts
@@ -1,6 +1,7 @@
 import Change from '../../src/-private/change';
 import Empty from '../../src/-private/empty';
 import { markUndefinedLeafKeys } from '../../src/utils/mark-undefined-leaf-keys';
+import isObject from '../../src/utils/is-object';
 
 const safeGet = function(obj: Record<string, any>, key: string) {
   return obj[key];
@@ -10,7 +11,7 @@ describe('Unit | Utility | normalize object', () => {
   it('it does nothing if no Change instance', () => {
     const changes = { value: 'Ivan' };
     const content = { value: 'Ivan', other: 'value' };
-    const value = markUndefinedLeafKeys(changes, content, { safeGet });
+    const value = markUndefinedLeafKeys(changes, content, { safeGet, isObject });
 
     expect(value).toEqual({ value: 'Ivan' });
   });
@@ -18,7 +19,7 @@ describe('Unit | Utility | normalize object', () => {
   it('it set EMPTY for missing key', () => {
     const changes = { name: new Change({ nickname: 'foo' }) };
     const content = { name: { nickname: 'bar', other: 'value' } };
-    const value = markUndefinedLeafKeys(changes, content, { safeGet });
+    const value = markUndefinedLeafKeys(changes, content, { safeGet, isObject });
 
     expect(value).toEqual({ name: new Change({ nickname: 'foo', other: new Empty() }) });
   });
@@ -26,7 +27,7 @@ describe('Unit | Utility | normalize object', () => {
   it('it set EMPTY for missing key with an array', () => {
     const changes = { name: new Change({ nickname: ['foo'] }) };
     const content = { name: { nickname: ['foo'], other: 'value' } };
-    const value = markUndefinedLeafKeys(changes, content, { safeGet });
+    const value = markUndefinedLeafKeys(changes, content, { safeGet, isObject });
 
     expect(value).toEqual({ name: new Change({ nickname: ['foo'], other: new Empty() }) });
   });
@@ -34,7 +35,7 @@ describe('Unit | Utility | normalize object', () => {
   it('it set EMPTY for missing nested with sibling keys', () => {
     const changes = { org: new Change({ usa: { name: 'USA' } }) };
     const content = { org: { usa: { name: 'usa' }, au: { name: 'au' } } };
-    const value = markUndefinedLeafKeys(changes, content, { safeGet });
+    const value = markUndefinedLeafKeys(changes, content, { safeGet, isObject });
 
     expect(value).toEqual({ org: new Change({ usa: { name: 'USA' }, au: new Empty() }) });
   });
@@ -42,7 +43,7 @@ describe('Unit | Utility | normalize object', () => {
   it('it set EMPTY for missing nested', () => {
     const changes = { org: new Change({ usa: { name: 'USA' } }) };
     const content = { org: { usa: { name: 'usa', foo: 'other' } } };
-    const value = markUndefinedLeafKeys(changes, content, { safeGet });
+    const value = markUndefinedLeafKeys(changes, content, { safeGet, isObject });
 
     expect(value).toEqual({ org: new Change({ usa: { name: 'USA', foo: new Empty() } }) });
   });

--- a/test/utils/normalize-object.test.ts
+++ b/test/utils/normalize-object.test.ts
@@ -1,39 +1,40 @@
 import Change from '../../src/-private/change';
 import Empty from '../../src/-private/empty';
 import normalizeObject, { normalizeEmptyObject } from '../../src/utils/normalize-object';
+import isObject from '../../src/utils/is-object';
 
 describe('Unit | Utility | normalize object', () => {
   it('it returns value', () => {
     const objA = new Change('Ivan');
-    const value = normalizeObject(objA);
+    const value = normalizeObject(objA, isObject);
 
     expect(value).toBe('Ivan');
   });
 
   it('it returns value object without Change', () => {
     const objA = { value: 'Ivan' };
-    const value = normalizeObject(objA);
+    const value = normalizeObject(objA, isObject);
 
     expect(value).toEqual({ value: 'Ivan' });
   });
 
   it('it returns value from nested', () => {
     const objA = { name: new Change('Ivan') };
-    const value = normalizeObject(objA);
+    const value = normalizeObject(objA, isObject);
 
     expect(value).toEqual({ name: 'Ivan' });
   });
 
   it('it returns multiple values from nested', () => {
     const objA = { name: new Change('Ivan'), foo: new Change('bar') };
-    const value = normalizeObject(objA);
+    const value = normalizeObject(objA, isObject);
 
     expect(value).toEqual({ name: 'Ivan', foo: 'bar' });
   });
 
   it('it returns for deep nested', () => {
     const objA = { details: { name: new Change('Ivan') } };
-    const value = normalizeObject(objA);
+    const value = normalizeObject(objA, isObject);
 
     expect(value).toEqual({ details: { name: 'Ivan' } });
   });
@@ -42,35 +43,35 @@ describe('Unit | Utility | normalize object', () => {
 describe('Unit | Utility | normalize empty object', () => {
   it('it returns value', () => {
     const objA = new Empty();
-    const value = normalizeEmptyObject(objA);
+    const value = normalizeEmptyObject(objA, isObject);
 
     expect(value).toBeUndefined();
   });
 
   it('it returns value object without Empty', () => {
     const objA = { value: 'Ivan' };
-    const value = normalizeEmptyObject(objA);
+    const value = normalizeEmptyObject(objA, isObject);
 
     expect(value).toEqual({ value: 'Ivan' });
   });
 
   it('it returns value from nested', () => {
     const objA = { name: new Empty() };
-    const value = normalizeEmptyObject(objA);
+    const value = normalizeEmptyObject(objA, isObject);
 
     expect(value).toEqual({ name: undefined });
   });
 
   it('it returns multiple values from nested', () => {
     const objA = { name: new Empty(), foo: new Empty() };
-    const value = normalizeEmptyObject(objA);
+    const value = normalizeEmptyObject(objA, isObject);
 
     expect(value).toEqual({ name: undefined, foo: undefined });
   });
 
   it('it returns for deep nested', () => {
     const objA = { details: { name: new Empty() } };
-    const value = normalizeEmptyObject(objA);
+    const value = normalizeEmptyObject(objA, isObject);
 
     expect(value).toEqual({ details: { name: undefined } });
   });

--- a/test/utils/object-tree-node.test.ts
+++ b/test/utils/object-tree-node.test.ts
@@ -1,9 +1,10 @@
 import { ObjectTreeNode } from '../../src/utils/object-tree-node';
 import Change from '../../src/-private/change';
+import isObject from '../../src/utils/is-object';
 
 describe('Unit | Utility | object tree node', () => {
   it('it returns changes', () => {
-    const result = new ObjectTreeNode({ name: 'z' }, { name: 'c' });
+    const result = new ObjectTreeNode({ name: 'z' }, { name: 'c' }, isObject);
 
     expect(result.changes).toEqual({ name: 'z' });
     expect(result.proxy.name).toBe('z');
@@ -12,7 +13,7 @@ describe('Unit | Utility | object tree node', () => {
 
   it('it returns nested children', () => {
     const initialVal = { details: { name: 'z' } };
-    const result = new ObjectTreeNode(initialVal, { details: { name: 'c' } });
+    const result = new ObjectTreeNode(initialVal, { details: { name: 'c' } }, isObject);
 
     expect(result.changes).toEqual({ details: { name: 'z' } });
     expect(result.unwrap()).toEqual({ details: { name: 'z' } });
@@ -25,7 +26,7 @@ describe('Unit | Utility | object tree node', () => {
 
   it('can set nested value on returned proxy', () => {
     const initialVal = { details: { name: 'z', email: '@' } };
-    const result = new ObjectTreeNode(initialVal, { details: { name: 'c' } });
+    const result = new ObjectTreeNode(initialVal, { details: { name: 'c' } }, isObject);
 
     result.proxy.details['name'] = 'bla bla';
     expect(result.proxy.details.name).toBe('bla bla');
@@ -36,14 +37,18 @@ describe('Unit | Utility | object tree node', () => {
 
   it('it works with arrays', () => {
     const initialVal = { users: ['user1', 'user2'] };
-    const result = new ObjectTreeNode(initialVal);
+    const result = new ObjectTreeNode(initialVal, {}, isObject);
 
     expect(result.proxy.users).toEqual(['user1', 'user2']);
     expect(result.proxy.users.length).toEqual(2);
   });
 
   it('unwrap merges sibling keys', () => {
-    const result = new ObjectTreeNode({ name: new Change('z') }, { name: 'c', email: '@email' });
+    const result = new ObjectTreeNode(
+      { name: new Change('z') },
+      { name: 'c', email: '@email' },
+      isObject
+    );
 
     expect(result.unwrap()).toEqual({ name: 'z', email: '@email' });
   });


### PR DESCRIPTION
For Ember usage.

@andreyfel 👋 How would you modify isObject for the Ember case.  Would it include `!isObjectProxy || !isArrayProxy`?

ref https://github.com/poteto/ember-changeset/pull/488