### PR TITLE
Simplify #get logic with return early for primitive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -862,7 +862,17 @@ export class BufferedChangeset implements IChangeset {
     let [baseKey, ...remaining] = key.split('.');
     let changes: Changes = this[CHANGES];
     let content: Content = this[CONTENT];
+    if (
+      Object.prototype.hasOwnProperty.call(changes, baseKey) &&
+      !isObject(this.safeGet(changes, key)) &&
+      this.safeGet(changes, key) !== undefined
+    ) {
+      // if safeGet returns a primitive, then go ahead return
+      return this.safeGet(changes, key);
+    }
 
+    // At this point, we may have a changes object, a dot separated key, or a need to access the `key`
+    // on `this` or `content`
     if (Object.prototype.hasOwnProperty.call(changes, baseKey) && hasChanges(changes)) {
       let baseChanges = changes[baseKey];
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -46,7 +46,7 @@ const objectProxyHandler = {
       return childValue;
     } else if (node.content) {
       const nodeContent = node.content;
-      if (node.safeGet(nodeContent, key) || typeof node.safeGet(nodeContent, key) === 'function') {
+      if (node.safeGet(nodeContent, key)) {
         return node.safeGet(nodeContent, key);
       }
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -113,15 +113,6 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyChangeset.toString()).toEqual('changeset:[object Object]');
   });
 
-  it('content can be an empty hash', () => {
-    expect.assertions(1);
-
-    const emptyObject = {};
-    const dummyChangeset = new ValidatedChangeset(emptyObject, lookupValidator(dummyValidations));
-
-    expect(dummyChangeset.toString()).toEqual('changeset:[object Object]');
-  });
-
   /**
    * #error
    */


### PR DESCRIPTION
This may help this issue and allow us to rely on Ember.get in ember-changeset.


https://github.com/poteto/ember-changeset/issues/502#issuecomment-642782851