### PR TITLE
Exclude RegExp objects from isObject test

### DIFF
--- a/src/utils/is-object.ts
+++ b/src/utils/is-object.ts
@@ -1,3 +1,3 @@
 export default function isObject<T>(val: T): boolean {
-  return val !== null && typeof val === 'object' && !(val instanceof Date) && !Array.isArray(val);
+  return val !== null && typeof val === 'object' && !(val instanceof Date || val instanceof RegExp) && !Array.isArray(val);
 }

--- a/test/utils/is-object.test.ts
+++ b/test/utils/is-object.test.ts
@@ -21,6 +21,11 @@ describe('Unit | Utility | is object', function() {
       label: 'ObjectProxies',
       value: new Proxy({ content: Object.create({ foo: 'bar' }) }, {}),
       expected: true
+    },
+    {
+      label: 'RegExps',
+      value: /foo/,
+      expected: false
     }
   ];
 


### PR DESCRIPTION
RegExps are `typeof` object, so they get wrapped with ObjectTreeNode. Since you would never need to track the changes of a nested RegExp property, let's not do that. 