### PR TITLE
Add Validator class support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -512,7 +512,7 @@ export class BufferedChangeset implements IChangeset {
    *
    * @method validate
    */
-  validate(...validationKeys: string[]): Promise<any> {
+  async validate(...validationKeys: string[]): Promise<any> {
     if (keys(this.validationMap as object).length === 0 && !validationKeys.length) {
       return Promise.resolve(null);
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,11 @@ export type ValidatorMapFunc = {
     | Promise<ValidationResult>;
 };
 
+export interface ValidatorMapClass {
+  validate: ValidatorMapFunc;
+  [s: string]: any;
+};
+
 export type ValidatorMap =
   | { [s: string]: ValidatorMapFunc | ValidatorMapFunc[] | any }
   | null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,7 +50,7 @@ export type ValidatorMapFunc = {
     | Promise<ValidationResult>;
 };
 
-export interface ValidatorMapClass {
+export interface ValidatorClass {
   validate: ValidatorMapFunc;
   [s: string]: any;
 };

--- a/src/utils/flatten-validations.ts
+++ b/src/utils/flatten-validations.ts
@@ -8,7 +8,10 @@ function flatten(
 ): object {
   for (let key of keys) {
     const value: any = validatorMap[key];
-    if (isObject(value)) {
+    if (typeof value.validate === 'function') {
+      // class with .validate function
+      obj[key] = value;
+    } else if (isObject(value)) {
       flatten(value, obj, Object.keys(value), [...keysUpToFunction, key]);
     } else if (typeof value === 'function') {
       const dotSeparatedKeys = [...keysUpToFunction, key].join('.');

--- a/src/utils/validator-lookup.ts
+++ b/src/utils/validator-lookup.ts
@@ -16,7 +16,7 @@ export default function lookupValidator(validationMap: ValidatorMap): ValidatorA
     let validator: ValidatorMapFunc | ValidatorMapFunc[] | ValidatorClass = get(validations, key);
     const isValidatorClass = (maybeClass: unknown): maybeClass is ValidatorClass => !!(maybeClass as Record<string, any>).validate;
     if (validator && isValidatorClass(validator)) {
-      validator = validator.validate;
+      validator = validator.validate.bind(validator);
     }
 
     if (!validator || isObject(validator)) {

--- a/src/utils/validator-lookup.ts
+++ b/src/utils/validator-lookup.ts
@@ -1,7 +1,7 @@
 import handleMultipleValidations from './handle-multiple-validations';
 import isPromise from './is-promise';
 import isObject from './is-object';
-import { ValidatorAction, ValidatorMapFunc, ValidationResult, ValidatorMap } from '../types';
+import { ValidatorAction, ValidatorMapFunc, ValidatorMapClass, ValidationResult, ValidatorMap } from '../types';
 import get from './get-deep';
 
 /**
@@ -13,7 +13,11 @@ import get from './get-deep';
 export default function lookupValidator(validationMap: ValidatorMap): ValidatorAction {
   return ({ key, newValue, oldValue, changes, content }) => {
     const validations = validationMap || {};
-    let validator: ValidatorMapFunc | ValidatorMapFunc[] = get(validations, key);
+    let validator: ValidatorMapFunc | ValidatorMapFunc[] | ValidatorMapClass = get(validations, key);
+    const isValidatorClass = (maybeClass: unknown): maybeClass is ValidatorMapClass => !!(maybeClass as Record<string, any>).validate;
+    if (validator && isValidatorClass(validator)) {
+      validator = validator.validate;
+    }
 
     if (!validator || isObject(validator)) {
       return true;

--- a/src/utils/validator-lookup.ts
+++ b/src/utils/validator-lookup.ts
@@ -1,7 +1,7 @@
 import handleMultipleValidations from './handle-multiple-validations';
 import isPromise from './is-promise';
 import isObject from './is-object';
-import { ValidatorAction, ValidatorMapFunc, ValidatorMapClass, ValidationResult, ValidatorMap } from '../types';
+import { ValidatorAction, ValidatorMapFunc, ValidatorClass, ValidationResult, ValidatorMap } from '../types';
 import get from './get-deep';
 
 /**
@@ -13,8 +13,8 @@ import get from './get-deep';
 export default function lookupValidator(validationMap: ValidatorMap): ValidatorAction {
   return ({ key, newValue, oldValue, changes, content }) => {
     const validations = validationMap || {};
-    let validator: ValidatorMapFunc | ValidatorMapFunc[] | ValidatorMapClass = get(validations, key);
-    const isValidatorClass = (maybeClass: unknown): maybeClass is ValidatorMapClass => !!(maybeClass as Record<string, any>).validate;
+    let validator: ValidatorMapFunc | ValidatorMapFunc[] | ValidatorClass = get(validations, key);
+    const isValidatorClass = (maybeClass: unknown): maybeClass is ValidatorClass => !!(maybeClass as Record<string, any>).validate;
     if (validator && isValidatorClass(validator)) {
       validator = validator.validate;
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2175,8 +2175,11 @@ describe('Unit | Utility | changeset', () => {
 
   it('#validate/0 works with a class', async () => {
     class PersonalValidator {
-      async validate(key: string, newValue: unknown) {
+      _validate() {
         return 'oh no';
+      }
+      async validate(key: string, newValue: unknown) {
+        return this._validate();
       }
     }
     const validationMap = {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,8 @@
-import { Changeset, ValidatedChangeset } from '../src';
+import { Changeset } from '../src';
 import get from '../src/utils/get-deep';
 import set from '../src/utils/set-deep';
 import lookupValidator from '../src/utils/validator-lookup';
+import { prependOnceListener } from 'process';
 
 let dummyModel: any;
 const exampleArray: Array<any> = [];
@@ -2170,6 +2171,31 @@ describe('Unit | Utility | changeset', () => {
     myChangeset.set('isOptionTwo', true);
     await myChangeset.validate();
     expect(myChangeset.isInvalid).toEqual(false);
+  });
+
+  it('#validate/0 works with a class', async () => {
+    class PersonalValidator {
+      async validate(key: string, newValue: unknown) {
+        return 'oh no';
+      }
+    }
+    const validationMap = {
+      name: new PersonalValidator()
+    };
+    dummyModel.name = 'J';
+    let dummyChangeset = Changeset(dummyModel, lookupValidator(validationMap), validationMap);
+    dummyChangeset.name = null;
+
+    await dummyChangeset.validate();
+
+    expect(get(dummyChangeset, 'errors.length')).toBe(1);
+    expect(get(dummyChangeset, 'error.name.validation')).toEqual('oh no');
+    expect(dummyChangeset.changes).toEqual([
+      {
+        key: 'name',
+        value: null,
+      }
+    ]);
   });
 
   it('#isInvalid does not trigger validations without validate keys', async () => {


### PR DESCRIPTION
Previously, we only allowed objects, nested objects, functions and arrays

ref https://github.com/poteto/ember-changeset-validations/issues/197