### PR TITLE
Add failing test for #prepare with initial dummyModel with obj prop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,14 +185,10 @@ export class BufferedChangeset implements IChangeset {
   }
 
   get _bareChanges() {
-    function transform(c: Change) {
-      return c.value;
-    }
-
     let obj = this[CHANGES];
 
-    return keys(obj).reduce((newObj: { [key: string]: any }, key: string) => {
-      newObj[key] = transform(obj[key]);
+    return getKeyValues(obj).reduce((newObj: { [key: string]: any }, { key, value }) => {
+      newObj[key] = value;
       return newObj;
     }, Object.create(null));
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1312,6 +1312,15 @@ describe('Unit | Utility | changeset', () => {
     expect(() => dummyChangeset.prepare(() => null)).toThrow();
   });
 
+  it('#prepare works with initial model containing an object property', () => {
+    const dummyChangeset = Changeset(Object.assign({ obj: {} },));
+
+    dummyChangeset.get('obj').unwrap();
+    dummyChangeset.prepare(function (changes) { return changes; });
+
+    expect(dummyChangeset.isPristine).toEqual(true);
+  });
+
   /**
    * #execute
    */


### PR DESCRIPTION
This adds the failing test that reveals an issue with the initial model having a property that is an object and calling `#prepare/1` after accessing that object. The `changes` arg that is passed to the callback function contains unintentional changes around the object property previously accessed. 

NOTE: the issue doesn't surface if you access a primitive leaf key like `changeset.obj.name`. It only happens when accessing `changeset.obj` regardless whether you call `unwrap` on it. 