### PR TITLE
#unexecute if save fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,19 @@ changeset.on('execute', callback);
 changeset.execute();
 ```
 
+#### `unexecute`
+
+Undo changes made to underlying Object for changeset. This is often useful if you want to remove changes from underlying Object if `save` fails.
+
+```js
+changeset
+  .save()
+  .catch(() => {
+    // save applies changes to the underlying Object via this.execute(). This may be undesired for your use case.
+    dummyChangeset.unexecute();
+  })
+```
+
 **[⬆️ back to top](#api)**
 
 #### `save`

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,6 +386,17 @@ export class BufferedChangeset implements IChangeset {
     return this;
   }
 
+  unexecute(): this {
+    if (this[PREVIOUS_CONTENT]) {
+      this[CONTENT] = this.mergeDeep(this[CONTENT], this[PREVIOUS_CONTENT], {
+        safeGet: this.safeGet,
+        safeSet: this.safeSet
+      });
+    }
+
+    return this;
+  }
+
   /**
    * Executes the changeset and saves the underlying content.
    *
@@ -417,12 +428,6 @@ export class BufferedChangeset implements IChangeset {
 
       return result;
     } catch (e) {
-      if (this[PREVIOUS_CONTENT]) {
-        this[CONTENT] = this.mergeDeep(content, this[PREVIOUS_CONTENT], {
-          safeGet: this.safeGet,
-          safeSet: this.safeSet
-        });
-      }
       throw e;
     }
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1623,7 +1623,7 @@ describe('Unit | Utility | changeset', () => {
       .finally(() => done());
   });
 
-  it('#save restores values on content after rejected Promise', done => {
+  it('#save restores values on content after rejected Promise if user calls unexecute', done => {
     expect.assertions(2);
 
     dummyModel.name = 'previous';
@@ -1644,6 +1644,9 @@ describe('Unit | Utility | changeset', () => {
       .save()
       .then(() => {
         expect(false).toBeTruthy();
+      })
+      .catch(() => {
+        dummyChangeset.unexecute();
       })
       .finally(() => {
         expect(dummyModel.name).toEqual('previous');


### PR DESCRIPTION
Partial revert: #80 

ref https://github.com/poteto/ember-changeset/issues/354

In order to access `model.errors`, we need to persist those changes on the underlying model.  As a result, `unexecute` is opt in now instead of by default.