### PR TITLE
Implement support for Arrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,5 @@ jobs:
         node-version: 12.x
     - run: npm install
     - name: "Test: ${{ matrix.lib }}"
-      run: npm run test:${{ matrix.lib }}
+      run: npm run test-external:${{ matrix.lib }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,25 @@ jobs:
       run: npm run lint
     - name: test
       run: npm run test
+
+  compat:
+    name: Compatibility
+    env:
+      CI: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lib:
+          - ember-changeset
+          - ember-changeset-validations
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v2-beta
+      with:
+        node-version: 12.x
+    - run: npm install
+    - name: "Test: ${{ matrix.lib }}"
+      run: npm run test:${{ matrix.lib }}
+

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest",
     "test:all": "npm run test && npm run test-external:ember-changeset && npm run test-external:ember-changeset-validations",
     "test.watch": "jest --watch",
+    "test:debug:named": "node --inspect-brk node_modules/.bin/jest --runInBand --watch --testNamePattern",
     "lint": "eslint .",
     "prepare": "npm run build",
     "prepublishOnly": "npm run test && npm run lint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -955,7 +955,7 @@ export class BufferedChangeset implements IChangeset {
           const baseContent = this.safeGet(content, baseKey);
           const subContent = this.getDeep(baseContent, remaining.join('.'));
           const subChanges = getSubObject(changes, key);
-          // give back and object that can further retrieve changes and/or content
+          // give back an object that can further retrieve changes and/or content
           const tree = new ObjectTreeNode(subChanges, subContent, this.getDeep, this.isObject);
           return tree.proxy;
         } else if (typeof result !== 'undefined') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   ValidatorAction,
   ValidatorMap
 } from './types';
+import { isArrayObject } from './utils/array-object';
 
 export {
   CHANGESET,
@@ -919,7 +920,9 @@ export class BufferedChangeset implements IChangeset {
     let content: Content = this[CONTENT];
     if (Object.prototype.hasOwnProperty.call(changes, baseKey)) {
       const changesValue = this.getDeep(changes, key);
-      if (!this.isObject(changesValue) && changesValue !== undefined) {
+      const isObject = this.isObject(changesValue);
+
+      if (!isObject && changesValue !== undefined) {
         // if safeGet returns a primitive, then go ahead return
         return changesValue;
       }
@@ -960,6 +963,16 @@ export class BufferedChangeset implements IChangeset {
           return tree.proxy;
         } else if (typeof result !== 'undefined') {
           return result;
+        }
+        const baseContent = this.safeGet(content, baseKey);
+
+        if (isArrayObject(normalizedBaseChanges) && Array.isArray(baseContent)) {
+          const subChanges = getSubObject(changes, key);
+
+          // give back an object that can further retrieve changes and/or content
+          const tree = new ObjectTreeNode(subChanges, baseContent, this.getDeep, this.isObject);
+
+          return tree.proxy;
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -969,6 +969,10 @@ export class BufferedChangeset implements IChangeset {
         if (Array.isArray(baseContent)) {
           const subChanges = getSubObject(changes, key);
 
+          if (!subChanges) {
+            return this.getDeep(baseContent, remaining.join('.'));
+          }
+
           // give back an object that can further retrieve changes and/or content
           const tree = new ObjectTreeNode(subChanges, baseContent, this.getDeep, this.isObject);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -966,13 +966,13 @@ export class BufferedChangeset implements IChangeset {
         }
         const baseContent = this.safeGet(content, baseKey);
 
-        if (isArrayObject(normalizedBaseChanges) && Array.isArray(baseContent)) {
+        if (Array.isArray(baseContent)) {
           const subChanges = getSubObject(changes, key);
 
           // give back an object that can further retrieve changes and/or content
           const tree = new ObjectTreeNode(subChanges, baseContent, this.getDeep, this.isObject);
 
-          return tree.proxy;
+          return tree;
         }
       }
 

--- a/src/utils/array-object.ts
+++ b/src/utils/array-object.ts
@@ -1,4 +1,6 @@
 export function isArrayObject(obj: Record<string, any>) {
+  if (!obj) return false;
+
   let maybeIndicies = Object.keys(obj);
 
   return maybeIndicies.every(key => Number.isInteger(parseInt(key, 10)));

--- a/src/utils/array-object.ts
+++ b/src/utils/array-object.ts
@@ -1,0 +1,22 @@
+export function isArrayObject(obj: Record<string, any>) {
+  let maybeIndicies = Object.keys(obj);
+
+  return maybeIndicies.every(key => Number.isInteger(parseInt(key, 10)));
+}
+
+export function arrayToObject(array: any[]): Record<string, any> {
+  return array.reduce((obj, item, index) => {
+    obj[index] = item;
+    return obj;
+  }, {} as Record<string, any>);
+}
+
+export function objectToArray(obj: Record<string, any>): any[] {
+  let result: any[] = [];
+
+  for (let [index, value] of Object.entries(obj)) {
+    result[parseInt(index, 10)] = value;
+  }
+
+  return result;
+}

--- a/src/utils/merge-deep.ts
+++ b/src/utils/merge-deep.ts
@@ -1,5 +1,6 @@
 import Change, { getChangeValue, isChange } from '../-private/change';
 import normalizeObject from './normalize-object';
+import { isArrayObject, objectToArray, arrayToObject } from './array-object';
 
 interface Options {
   safeGet: any;
@@ -151,9 +152,14 @@ export default function mergeDeep(
     };
   let sourceIsArray = Array.isArray(source);
   let targetIsArray = Array.isArray(target);
+  let sourceIsArrayLike = isArrayObject(source);
   let sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
 
   if (!sourceAndTargetTypesMatch) {
+    if (targetIsArray && sourceIsArrayLike) {
+      return objectToArray(mergeTargetAndSource(arrayToObject(target), source, options));
+    }
+
     return source;
   } else if (sourceIsArray) {
     return source;

--- a/src/utils/merge-deep.ts
+++ b/src/utils/merge-deep.ts
@@ -152,10 +152,11 @@ export default function mergeDeep(
     };
   let sourceIsArray = Array.isArray(source);
   let targetIsArray = Array.isArray(target);
-  let sourceIsArrayLike = isArrayObject(source);
   let sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
 
   if (!sourceAndTargetTypesMatch) {
+    let sourceIsArrayLike = isArrayObject(source);
+
     if (targetIsArray && sourceIsArrayLike) {
       return objectToArray(mergeTargetAndSource(arrayToObject(target), source, options));
     }

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -3,6 +3,7 @@ import isObject from './is-object';
 import setDeep from './set-deep';
 import Change, { getChangeValue, isChange } from '../-private/change';
 import normalizeObject from './normalize-object';
+import {objectToArray, arrayToObject} from './array-object';
 
 const objectProxyHandler = {
   /**
@@ -18,6 +19,7 @@ const objectProxyHandler = {
 
     if (node.changes.hasOwnProperty && node.changes.hasOwnProperty(key)) {
       childValue = node.safeGet(node.changes, key);
+
       if (typeof childValue === 'undefined') {
         return;
       }
@@ -118,6 +120,10 @@ class ObjectTreeNode implements ProxyHandler {
       if (isObject(content)) {
         changes = normalizeObject(changes, this.isObject);
         return { ...content, ...changes };
+      } else if (Array.isArray(content)) {
+        changes = normalizeObject(changes, this.isObject);
+
+        return objectToArray({ ...arrayToObject(content), ...changes });
       }
     }
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -81,10 +81,6 @@ const objectProxyHandler = {
     return Reflect.has(node.changes, prop);
   },
 
-  apply(node: ProxyHandler, thisArg: any, args: any[]) {
-    return node.call(thisArg, ...args);
-  },
-
   set(node: ProxyHandler, key: string, value: unknown): any {
     // dont want to set private properties on changes (usually found on outside actors)
     if (key.startsWith('_')) {

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -13,16 +13,6 @@ const objectProxyHandler = {
    */
   get(node: ProxyHandler, key: string): any {
     if (typeof key === 'symbol') {
-      if (key === Symbol.iterator) {
-        return true;
-      }
-
-      // This convinces Jest/expect that our object is an array.
-      // see: expect/build/jasmineUtils#eq
-      if (key === Symbol.toStringTag && Array.isArray(node.content)) {
-        return 'Array';
-      }
-
       return;
     }
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -4,6 +4,7 @@ import setDeep from './set-deep';
 import Change, { getChangeValue, isChange } from '../-private/change';
 import normalizeObject from './normalize-object';
 import { objectToArray, arrayToObject, isArrayObject } from './array-object';
+import mergeDeep from './merge-deep';
 
 const objectProxyHandler = {
   /**
@@ -133,7 +134,7 @@ class ObjectTreeNode implements ProxyHandler {
       } else if (Array.isArray(content)) {
         changes = normalizeObject(changes, this.isObject);
 
-        return objectToArray({ ...arrayToObject(content), ...changes });
+        return objectToArray(mergeDeep(arrayToObject(content), changes));
       }
     }
 

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -1,6 +1,5 @@
 import Change, { getChangeValue, isChange } from '../-private/change';
 import isObject from './is-object';
-import getDeep from './get-deep';
 
 interface Options {
   safeSet: any;
@@ -60,6 +59,12 @@ export default function setDeep(
   for (let i = 0; i < keys.length; i++) {
     let prop = keys[i];
 
+    if (Array.isArray(target) && parseInt(prop, 10) < 0) {
+      throw new Error(
+        'Negative indices are not allowed as arrays do not serialize values at negative indices'
+      );
+    }
+
     const isObj = isObject(target[prop]);
     const isArray = Array.isArray(target[prop]);
     const isComplex = isObj || isArray;
@@ -72,6 +77,7 @@ export default function setDeep(
       if (isObject(changeValue)) {
         // if an object, we don't want to lose sibling keys
         const siblings = findSiblings(changeValue, keys);
+
         const resolvedValue = isChange(value) ? getChangeValue(value) : value;
         target[prop] = new Change(
           setDeep(siblings, keys.slice(1, keys.length).join('.'), resolvedValue, options)

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -1,5 +1,6 @@
 import Change, { getChangeValue, isChange } from '../-private/change';
 import isObject from './is-object';
+import { isArrayObject } from './array-object';
 
 interface Options {
   safeSet: any;
@@ -79,9 +80,14 @@ export default function setDeep(
         const siblings = findSiblings(changeValue, keys);
 
         const resolvedValue = isChange(value) ? getChangeValue(value) : value;
-        target[prop] = new Change(
-          setDeep(siblings, keys.slice(1, keys.length).join('.'), resolvedValue, options)
-        );
+        const nestedKeys =
+          Array.isArray(target) || isArrayObject(target)
+            ? keys.slice(i + 1, keys.length).join('.') // remove first key segment as well as the index
+            : keys.slice(1, keys.length).join('.'); // remove first key segment
+
+        const newValue = setDeep(siblings, nestedKeys, resolvedValue, options);
+
+        target[prop] = new Change(newValue);
 
         // since we are done with the `path`, we can terminate the for loop and return control
         break;

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -1,5 +1,6 @@
 import Change, { getChangeValue, isChange } from '../-private/change';
 import isObject from './is-object';
+import getDeep from './get-deep';
 
 interface Options {
   safeSet: any;
@@ -60,10 +61,14 @@ export default function setDeep(
     let prop = keys[i];
 
     const isObj = isObject(target[prop]);
-    if (!isObj) {
+    const isArray = Array.isArray(target[prop]);
+    const isComplex = isObj || isArray;
+
+    if (!isComplex) {
       options.safeSet(target, prop, {});
-    } else if (isObj && isChange(target[prop])) {
+    } else if (isComplex && isChange(target[prop])) {
       let changeValue = getChangeValue(target[prop]);
+
       if (isObject(changeValue)) {
         // if an object, we don't want to lose sibling keys
         const siblings = findSiblings(changeValue, keys);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -771,6 +771,47 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyModel.name.short).toBe('foo');
   });
 
+  it('#set nested objects can contain arrays', () => {
+    expect.assertions(5);
+
+    dummyModel.contact = {
+      emails: ['bob@email.com', 'the_bob@email.com']
+    };
+
+    expect(get(dummyModel, 'contact.emails')).toEqual(['bob@email.com', 'the_bob@email.com']);
+
+    const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations));
+
+    expect(dummyChangeset.get('contact.emails')).toEqual(['bob@email.com', 'the_bob@email.com']);
+
+    dummyChangeset.set('contact.emails.0', 'fred@email.com');
+
+    expect(dummyChangeset.get('contact.emails.0')).toEqual('fred@email.com');
+
+    dummyChangeset.rollback();
+    expect(dummyChangeset.get('contact.emails')).toEqual(['bob@email.com', 'the_bob@email.com']);
+
+    dummyChangeset.set('contact.emails.0', 'fred@email.com');
+    dummyChangeset.set('contact.emails.1', 'the_fred@email.com');
+
+    expect(dummyChangeset.get('contact.emails')).toEqual(['fred@email.com', 'the_fred@email.com']);
+
+    dummyChangeset.execute();
+    expect(dummyModel.contact.emails).toEqual(['fred@email.com', 'the_fred@email.com']);
+  });
+
+  it('#set nested objects can create arrays', () => {
+    dummyModel.contact = {};
+
+    expect(get(dummyModel, 'contact.emails')).toEqual(undefined);
+    const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations));
+    expect(dummyChangeset.get('contact.emails')).toEqual(undefined);
+
+    dummyChangeset.set('contact.emails.0', 'fred@email.com');
+    expect(dummyChangeset.get('contact.emails.0')).toEqual('fred@email.com');
+    expect(dummyChangeset.get('contact.emails')).toEqual(['fred@email.com']);
+  });
+
   it('#set works for nested when the root key is "value"', () => {
     dummyModel.value = {};
     dummyModel.org = {};
@@ -1354,7 +1395,9 @@ describe('Unit | Utility | changeset', () => {
     const dummyChangeset = Changeset({ obj: {} });
 
     dummyChangeset.get('obj').unwrap();
-    dummyChangeset.prepare(function (changes) { return changes; });
+    dummyChangeset.prepare(function(changes) {
+      return changes;
+    });
 
     expect(dummyChangeset.isPristine).toEqual(true);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -812,11 +812,13 @@ describe('Unit | Utility | changeset', () => {
 
         expect(changeset.get('contact.emails.0')).toEqual('fred@email.com');
         expect(changeset.changes).toEqual([{ key: 'contact.emails.0', value: 'fred@email.com' }]);
+        expect(changeset.get('contact.emails')).toEqual(['fred@email.com']);
 
         changeset.rollback();
 
         expect(changeset.get('contact.emails.0')).toEqual('bob@email.com');
         expect(changeset.changes).toEqual([]);
+        expect(changeset.get('contact.emails')).toEqual(['bob@email.com']);
       });
 
       it('can be saved', () => {
@@ -837,20 +839,26 @@ describe('Unit | Utility | changeset', () => {
         const changeset = Changeset(initialData);
 
         changeset.set('contact.emails.1', 'fred@email.com');
-        changeset.set('contact.emails.3', 'greg@email.com');
 
         expect(changeset.get('contact.emails.1')).toEqual('fred@email.com');
-        expect(changeset.get('contact.emails.3')).toEqual('greg@email.com');
-        expect(changeset.changes).toEqual([
-          { key: 'contact.emails.1', value: 'fred@email.com' },
-          { key: 'contact.emails.3', value: 'greg@email.com' }
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          'bob@email.com',
+          'fred@email.com'
         ]);
+        expect(changeset.changes).toEqual([{ key: 'contact.emails.1', value: 'fred@email.com' }]);
 
+        changeset.set('contact.emails.3', 'greg@email.com');
+
+        expect(changeset.get('contact.emails.3')).toEqual('greg@email.com');
         expect(changeset.get('contact.emails').unwrap()).toEqual([
           'bob@email.com',
           'fred@email.com',
           undefined,
           'greg@email.com'
+        ]);
+        expect(changeset.changes).toEqual([
+          { key: 'contact.emails.1', value: 'fred@email.com' },
+          { key: 'contact.emails.3', value: 'greg@email.com' }
         ]);
       });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -823,7 +823,7 @@ describe('Unit | Utility | changeset', () => {
 
         expect(changeset.get('contact.emails.0')).toEqual('fred@email.com');
         expect(changeset.changes).toEqual([{ key: 'contact.emails.0', value: 'fred@email.com' }]);
-        expect(changeset.get('contact.emails')).toEqual(['fred@email.com']);
+        expect(changeset.get('contact.emails').unwrap()).toEqual(['fred@email.com']);
 
         changeset.rollback();
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -973,7 +973,7 @@ describe('Unit | Utility | changeset', () => {
         ]);
       });
 
-      it('can add a new object at once, and edit it', () => {
+      it('can add a new object all at once, and edit it', () => {
         const changeset = Changeset(initialData);
 
         changeset.set('contact.emails.1', {
@@ -996,7 +996,20 @@ describe('Unit | Utility | changeset', () => {
 
         changeset.set('contact.emails.1.primary', 'primary2@email.com');
 
-        expect(changeset.get('contact.emails.1.primary')).toEqual('primary2@email.com');
+        // expect(changeset.get('contact.emails.1.primary')).toEqual('primary2@email.com');
+        expect(changeset.changes).toEqual([
+          {
+            key: 'contact.emails.1',
+            value: {
+              primary: 'primary2@email.com',
+              funEmail: 'fun@email.com'
+            }
+          }
+        ]);
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          { primary: 'bob@email.com' },
+          { primary: 'primary2@email.com', funEmail: 'fun@email.com' }
+        ]);
       });
     });
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -879,6 +879,62 @@ describe('Unit | Utility | changeset', () => {
     });
   });
 
+  describe('arrays of objects within nested objects', () => {
+    describe('#set', () => {
+      let initialData: { contact: { emails: Record<string, string>[] } } = {
+        contact: { emails: [] }
+      };
+
+      beforeEach(() => {
+        initialData = { contact: { emails: [{ primary: 'bob@email.com' }] } };
+      });
+
+      it('can modify properties on an entry', () => {
+        const changeset = Changeset(initialData);
+
+        changeset.set('contact.emails.0.primary', 'fun@email.com');
+
+        expect(changeset.get('contact.emails.0.primary')).toEqual('fun@email.com');
+        expect(changeset.get('contact.emails').unwrap()).toEqual([{ primary: 'fun@email.com' }]);
+        expect(changeset.changes).toEqual([
+          { key: 'contact.emails.0.primary', value: 'fun@email.com' }
+        ]);
+      });
+
+      it('can add properties to an entry', () => {
+        const changeset = Changeset(initialData);
+
+        changeset.set('contact.emails.0.funEmail', 'fun@email.com');
+
+        expect(changeset.get('contact.emails.0.funEmail')).toEqual('fun@email.com');
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          { primary: 'bob@email.com', funEmail: 'fun@email.com' }
+        ]);
+        expect(changeset.changes).toEqual([
+          { key: 'contact.emails.0.funEmail', value: 'fun@email.com' }
+        ]);
+      });
+
+      it('can add new properties to new entries', () => {
+        const changeset = Changeset(initialData);
+
+        changeset.set('contact.emails.1.funEmail', 'fun@email.com');
+        changeset.set('contact.emails.1.primary', 'primary@email.com');
+
+        expect(changeset.get('contact.emails.1.funEmail')).toEqual('fun@email.com');
+        expect(changeset.get('contact.emails.1.primary')).toEqual('primary@email.com');
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          { primary: 'bob@email.com' },
+          { primary: 'primary@email.com', funEmail: 'fun@email.com' }
+        ]);
+        expect(changeset.changes).toEqual([
+          { key: 'contact.emails.1.funEmail', value: 'fun@email.com' },
+          { key: 'contact.emails.1.primary', value: 'primary@email.com' }
+        ]);
+      });
+    });
+  });
+
   it('#set nested objects cannot create arrays when we have no hints', () => {
     dummyModel.contact = {};
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -881,7 +881,6 @@ describe('Unit | Utility | changeset', () => {
         expect(changeset.get('contact.emails')).toEqual(['bob@email.com']);
 
         expect(() => {
-          debugger;
           changeset.set('contact.emails.-1', 'fred@email.com');
         }).toThrow(
           'Negative indices are not allowed as arrays do not serialize values at negative indices'

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -811,6 +811,7 @@ describe('Unit | Utility | changeset', () => {
         changeset.set('contact.emails.0', 'fred@email.com');
 
         expect(changeset.isValid).toEqual(false);
+        expect(changeset.isDirty).toEqual(true);
         expect(changeset.errors).toEqual([
           { key: 'contact.emails.0', validation: 'Fred is banned', value: 'fred@email.com' }
         ]);
@@ -871,6 +872,10 @@ describe('Unit | Utility | changeset', () => {
           { key: 'contact.emails.1', value: 'fred@email.com' },
           { key: 'contact.emails.3', value: 'greg@email.com' }
         ]);
+
+        expect(changeset.change).toEqual({
+          contact: { emails: { 1: 'fred@email.com', 3: 'greg@email.com' } }
+        });
       });
 
       it('can remove items from the array', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -973,7 +973,7 @@ describe('Unit | Utility | changeset', () => {
         ]);
       });
 
-      xit('can add a new object at once, and edit it', () => {
+      it('can add a new object at once, and edit it', () => {
         const changeset = Changeset(initialData);
 
         changeset.set('contact.emails.1', {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1099,6 +1099,8 @@ describe('Unit | Utility | changeset', () => {
         }
       ]);
 
+      expect(changeset.get('emails.0.fun')).toEqual('fun0@email.com');
+      expect(changeset.get('emails.0.primary')).toEqual('primary0@email.com');
       // does not need to be unwrapped
       expect(changeset.get('emails.0.value')).toEqual('the value');
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -873,6 +873,36 @@ describe('Unit | Utility | changeset', () => {
         ]);
       });
 
+      it('can remove items from the array', () => {
+        const changeset = Changeset(initialData);
+
+        changeset.set('contact.emails.1', 'fred@email.com');
+
+        expect(changeset.get('contact.emails.1')).toEqual('fred@email.com');
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          'bob@email.com',
+          'fred@email.com'
+        ]);
+        expect(changeset.changes).toEqual([{ key: 'contact.emails.1', value: 'fred@email.com' }]);
+
+        changeset.set('contact.emails.0', null);
+
+        expect(changeset.get('contact.emails.0')).toEqual(null);
+        expect(changeset.get('contact.emails').unwrap()).toEqual([null, 'fred@email.com']);
+        expect(changeset.changes).toEqual([
+          { key: 'contact.emails.0', value: null },
+          { key: 'contact.emails.1', value: 'fred@email.com' }
+        ]);
+
+        changeset.set('contact.emails.1', null);
+
+        expect(changeset.get('contact.emails').unwrap()).toEqual([null, null]);
+        expect(changeset.changes).toEqual([
+          { key: 'contact.emails.0', value: null },
+          { key: 'contact.emails.1', value: null }
+        ]);
+      });
+
       xit(`negative values are not allowed`, () => {
         // This test is currently disabled because setDeep doesn't have a reference to the
         // original array and setDeep is where we'd throw on invalid key values

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -944,7 +944,6 @@ describe('Unit | Utility | changeset', () => {
       it('can add properties to an entry', () => {
         const changeset = Changeset(initialData);
 
-        debugger;
         changeset.set('contact.emails.0.funEmail', 'fun@email.com');
 
         expect(changeset.get('contact.emails.0.funEmail')).toEqual('fun@email.com');
@@ -972,6 +971,32 @@ describe('Unit | Utility | changeset', () => {
           { key: 'contact.emails.1.funEmail', value: 'fun@email.com' },
           { key: 'contact.emails.1.primary', value: 'primary@email.com' }
         ]);
+      });
+
+      xit('can add a new object at once, and edit it', () => {
+        const changeset = Changeset(initialData);
+
+        changeset.set('contact.emails.1', {
+          funEmail: 'fun@email.com',
+          primary: 'primary@email.com'
+        });
+
+        expect(changeset.get('contact.emails.1.funEmail')).toEqual('fun@email.com');
+        expect(changeset.get('contact.emails.1.primary')).toEqual('primary@email.com');
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          { primary: 'bob@email.com' },
+          { primary: 'primary@email.com', funEmail: 'fun@email.com' }
+        ]);
+        expect(changeset.changes).toEqual([
+          {
+            key: 'contact.emails.1',
+            value: { funEmail: 'fun@email.com', primary: 'primary@email.com' }
+          }
+        ]);
+
+        changeset.set('contact.emails.1.primary', 'primary2@email.com');
+
+        expect(changeset.get('contact.emails.1.primary')).toEqual('primary2@email.com');
       });
     });
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -794,8 +794,10 @@ describe('Unit | Utility | changeset', () => {
     dummyChangeset.set('contact.emails.0', 'fred@email.com');
     dummyChangeset.set('contact.emails.1', 'the_fred@email.com');
 
-    expect(dummyChangeset.get('contact.emails')).toEqual(['fred@email.com', 'the_fred@email.com']);
+    // debugger;
+    // expect(dummyChangeset.get('contact.emails')).toEqual(['fred@email.com', 'the_fred@email.com']);
 
+    debugger
     dummyChangeset.execute();
     expect(dummyModel.contact.emails).toEqual(['fred@email.com', 'the_fred@email.com']);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -773,10 +773,21 @@ describe('Unit | Utility | changeset', () => {
 
   describe('arrays within nested objects', () => {
     describe('#set', () => {
-      let initialData: { contact: { emails: string[] } } = { contact: { emails: [] } };
+      let initialData: { contact: { emails?: string[] } } = { contact: { emails: [] } };
 
       beforeEach(() => {
         initialData = { contact: { emails: ['bob@email.com'] } };
+      });
+
+      it('#set nested objects cannot create arrays when we have no hints', () => {
+        initialData.contact = {};
+
+        const changeset = Changeset(initialData);
+        expect(changeset.get('contact.emails')).toEqual(undefined);
+
+        changeset.set('contact.emails.0', 'fred@email.com');
+        expect(changeset.get('contact.emails.0')).toEqual('fred@email.com');
+        expect(changeset.get('contact.emails')).toEqual({ '0': 'fred@email.com' });
       });
 
       it('works with validations', () => {
@@ -933,18 +944,6 @@ describe('Unit | Utility | changeset', () => {
         ]);
       });
     });
-  });
-
-  it('#set nested objects cannot create arrays when we have no hints', () => {
-    dummyModel.contact = {};
-
-    expect(get(dummyModel, 'contact.emails')).toEqual(undefined);
-    const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations));
-    expect(dummyChangeset.get('contact.emails')).toEqual(undefined);
-
-    dummyChangeset.set('contact.emails.0', 'fred@email.com');
-    expect(dummyChangeset.get('contact.emails.0')).toEqual('fred@email.com');
-    expect(dummyChangeset.get('contact.emails')).toEqual({ '0': 'fred@email.com' });
   });
 
   it('#set works for nested when the root key is "value"', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -779,7 +779,7 @@ describe('Unit | Utility | changeset', () => {
         initialData = { contact: { emails: ['bob@email.com'] } };
       });
 
-      it('#set nested objects cannot create arrays when we have no hints', () => {
+      it('nested objects cannot create arrays when we have no hints', () => {
         initialData.contact = {};
 
         const changeset = Changeset(initialData);
@@ -915,14 +915,15 @@ describe('Unit | Utility | changeset', () => {
       it('can add properties to an entry', () => {
         const changeset = Changeset(initialData);
 
+        debugger;
         changeset.set('contact.emails.0.funEmail', 'fun@email.com');
 
         expect(changeset.get('contact.emails.0.funEmail')).toEqual('fun@email.com');
-        expect(changeset.get('contact.emails').unwrap()).toEqual([
-          { primary: 'bob@email.com', funEmail: 'fun@email.com' }
-        ]);
         expect(changeset.changes).toEqual([
           { key: 'contact.emails.0.funEmail', value: 'fun@email.com' }
+        ]);
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          { primary: 'bob@email.com', funEmail: 'fun@email.com' }
         ]);
       });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -794,10 +794,9 @@ describe('Unit | Utility | changeset', () => {
     dummyChangeset.set('contact.emails.0', 'fred@email.com');
     dummyChangeset.set('contact.emails.1', 'the_fred@email.com');
 
-    // debugger;
+    // This is still in object format
     // expect(dummyChangeset.get('contact.emails')).toEqual(['fred@email.com', 'the_fred@email.com']);
 
-    debugger
     dummyChangeset.execute();
     expect(dummyModel.contact.emails).toEqual(['fred@email.com', 'the_fred@email.com']);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -996,7 +996,7 @@ describe('Unit | Utility | changeset', () => {
 
         changeset.set('contact.emails.1.primary', 'primary2@email.com');
 
-        // expect(changeset.get('contact.emails.1.primary')).toEqual('primary2@email.com');
+        expect(changeset.get('contact.emails.1.primary')).toEqual('primary2@email.com');
         expect(changeset.changes).toEqual([
           {
             key: 'contact.emails.1',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -800,7 +800,7 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyModel.contact.emails).toEqual(['fred@email.com', 'the_fred@email.com']);
   });
 
-  it('#set nested objects can create arrays', () => {
+  it('#set nested objects cannot create arrays when we have no hints', () => {
     dummyModel.contact = {};
 
     expect(get(dummyModel, 'contact.emails')).toEqual(undefined);
@@ -809,7 +809,7 @@ describe('Unit | Utility | changeset', () => {
 
     dummyChangeset.set('contact.emails.0', 'fred@email.com');
     expect(dummyChangeset.get('contact.emails.0')).toEqual('fred@email.com');
-    expect(dummyChangeset.get('contact.emails')).toEqual(['fred@email.com']);
+    expect(dummyChangeset.get('contact.emails')).toEqual({ '0': 'fred@email.com' });
   });
 
   it('#set works for nested when the root key is "value"', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1026,6 +1026,8 @@ describe('Unit | Utility | changeset', () => {
 
       changeset.set('emails.1', null);
 
+      expect(changeset.get('emails.0.fun')).toEqual('fun0@email.com');
+      expect(changeset.get('emails.0.primary')).toEqual('primary0@email.com');
       expect(changeset.get('emails').unwrap()).toEqual([
         {
           fun: 'fun0@email.com',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -934,7 +934,6 @@ describe('Unit | Utility | changeset', () => {
     it('can modify properties on an entry', () => {
       const changeset = Changeset(initialData);
 
-      debugger;
       changeset.set('emails.0.primary', 'fun@email.com');
 
       expect(changeset.get('emails.0.primary')).toEqual('fun@email.com');
@@ -1065,6 +1064,43 @@ describe('Unit | Utility | changeset', () => {
           }
         }
       ]);
+    });
+
+    it('can edit an object with a key of value after another array entry has been deleted', () => {
+      const changeset = Changeset({
+        emails: [
+          {
+            fun: 'fun0@email.com',
+            primary: 'primary0@email.com',
+            value: 'the value'
+          },
+          {
+            fun: 'fun1@email.com',
+            primary: 'primary1@email.com',
+            value: 'some value'
+          }
+        ]
+      });
+
+      changeset.set('emails.1', null);
+
+      expect(changeset.get('emails').unwrap()).toEqual([
+        {
+          fun: 'fun0@email.com',
+          primary: 'primary0@email.com',
+          value: 'the value'
+        },
+        null
+      ]);
+      expect(changeset.changes).toEqual([
+        {
+          key: 'emails.1',
+          value: null
+        }
+      ]);
+
+      // does not need to be unwrapped
+      expect(changeset.get('emails.0.value')).toEqual('the value');
     });
   });
 

--- a/test/utils/merge-deep.test.ts
+++ b/test/utils/merge-deep.test.ts
@@ -29,7 +29,6 @@ describe('Unit | Utility | merge deep', () => {
   it('works with arrays', () => {
     const objA = { employees: ['Ivan', 'Jan'] };
     const objB = { employees: { 0: new Change('Jull'), 1: new Change('Olafur') } };
-    debugger;
     const value = mergeDeep(objA, objB);
 
     expect(value).toEqual({ employees: ['Jull', 'Olafur'] });

--- a/test/utils/merge-deep.test.ts
+++ b/test/utils/merge-deep.test.ts
@@ -34,6 +34,23 @@ describe('Unit | Utility | merge deep', () => {
     expect(value).toEqual({ employees: ['Jull', 'Olafur'] });
   });
 
+  it('adds to arrays', () => {
+    const objA = { employees: ['Ivan'] };
+    const objB = { employees: { 1: new Change('Olafur') } };
+    const value = mergeDeep(objA, objB);
+
+    expect(value).toEqual({ employees: ['Ivan', 'Olafur'] });
+  });
+
+  it('removes from arrays', () => {
+    const objA = { employees: ['Ivan'] };
+    const objB = { employees: { 0: new Change(null) } };
+    const value = mergeDeep(objA, objB);
+
+    // this isn't really the same as removing, but it might be the best we can do?
+    expect(value).toEqual({ employees: [null] });
+  });
+
   it('it works with classes', () => {
     class Employee {
       names = [];

--- a/test/utils/merge-deep.test.ts
+++ b/test/utils/merge-deep.test.ts
@@ -26,6 +26,15 @@ describe('Unit | Utility | merge deep', () => {
     expect(value).toEqual({ company: { employees: ['Jull', 'Olafur'] } });
   });
 
+  it('works with arrays', () => {
+    const objA = { employees: ['Ivan', 'Jan'] };
+    const objB = { employees: { 0: new Change('Jull'), 1: new Change('Olafur') } };
+    debugger;
+    const value = mergeDeep(objA, objB);
+
+    expect(value).toEqual({ employees: ['Jull', 'Olafur'] });
+  });
+
   it('it works with classes', () => {
     class Employee {
       names = [];

--- a/test/utils/set-deep.test.ts
+++ b/test/utils/set-deep.test.ts
@@ -66,6 +66,20 @@ describe('Unit | Utility | set deep', () => {
     expect(value).toEqual({ entries: [{ prop: 'bar' }] });
   });
 
+  it('inserts primitive types into existing arrays', () => {
+    const objA = { entries: ['foo'] };
+    const value = setDeep(objA, 'entries.1', 'bar');
+
+    expect(value).toEqual({ entries: ['foo', 'bar'] });
+  });
+
+  it('inserts primitive types into empty arrays', () => {
+    const objA = { entries: [] };
+    const value = setDeep(objA, 'entries.0', 'bar');
+
+    expect(value).toEqual({ entries: ['bar'] });
+  });
+
   it('it does not lose sibling keys', () => {
     const objA = {
       name: {

--- a/test/utils/set-deep.test.ts
+++ b/test/utils/set-deep.test.ts
@@ -45,6 +45,27 @@ describe('Unit | Utility | set deep', () => {
     expect(value).toEqual({ name: { other: 'foo' } });
   });
 
+  it('handles existing arrays', () => {
+    const objA = { entries: [{ prop: 'foo' }] };
+    const value = setDeep(objA, 'entries.0.prop', 'bar');
+
+    expect(value).toEqual({ entries: [{ prop: 'bar' }] });
+  });
+
+  it('inserts data into existing arrays', () => {
+    const objA = { entries: [{ prop: 'foo' }] };
+    const value = setDeep(objA, 'entries.1.prop', 'bar');
+
+    expect(value).toEqual({ entries: [{ prop: 'foo' }, { prop: 'bar' }] });
+  });
+
+  it('inserts data into empty arrays', () => {
+    const objA = { entries: [] };
+    const value = setDeep(objA, 'entries.0.prop', 'bar');
+
+    expect(value).toEqual({ entries: [{ prop: 'bar' }] });
+  });
+
   it('it does not lose sibling keys', () => {
     const objA = {
       name: {

--- a/test/utils/set-deep.test.ts
+++ b/test/utils/set-deep.test.ts
@@ -66,6 +66,16 @@ describe('Unit | Utility | set deep', () => {
     expect(value).toEqual({ entries: [{ prop: 'bar' }] });
   });
 
+  it('does not allow inserting into arrays at negative values', () => {
+    const objA = { entries: [] };
+
+    expect(() => {
+      setDeep(objA, 'entries.-1.prop', 'bar');
+    }).toThrow(
+      'Negative indices are not allowed as arrays do not serialize values at negative indices'
+    );
+  });
+
   it('inserts primitive types into existing arrays', () => {
     const objA = { entries: ['foo'] };
     const value = setDeep(objA, 'entries.1', 'bar');

--- a/test/utils/set-deep.test.ts
+++ b/test/utils/set-deep.test.ts
@@ -228,6 +228,112 @@ describe('Unit | Utility | set deep', () => {
     });
   });
 
+  it('set on nested properties within an empty object', () => {
+    const objA = {
+      top: {}
+    };
+    let value = setDeep(objA, 'top.name', new Change('zoo'));
+
+    expect(value).toEqual({
+      top: {
+        name: new Change('zoo')
+      }
+    });
+
+    value = setDeep(value, 'top.foo.other', new Change('baz'));
+
+    expect(value).toEqual({
+      top: {
+        name: new Change('zoo'),
+        foo: {
+          other: new Change('baz')
+        }
+      }
+    });
+  });
+
+  describe('arrays at various nestings within an object', () => {
+    describe('array nested one level deep', () => {
+      it('sets when teh array is initially empty', () => {
+        const objA = {
+          top: []
+        };
+        let value = setDeep(objA, 'top.0.name', new Change('zoo'));
+
+        expect(value).toEqual({
+          top: [{ name: new Change('zoo') }]
+        });
+
+        value = setDeep(value, 'top.0.foo.other', new Change('baz'));
+
+        expect(value).toEqual({
+          top: [
+            {
+              name: new Change('zoo'),
+              foo: {
+                other: new Change('baz')
+              }
+            }
+          ]
+        });
+      });
+
+      it('sets with existing changes', () => {
+        const objA = {
+          top: [new Change({ foo: { other: 'bar' }, name: 'jimmy' })]
+        };
+        let value = setDeep(objA, 'top.0.name', new Change('zoo'));
+
+        expect(value).toEqual({
+          top: [
+            new Change({
+              foo: { other: 'bar' },
+              name: 'zoo' // value is not a Change instance
+            })
+          ]
+        });
+
+        value = setDeep(value, 'top.0.foo.other', new Change('baz'));
+
+        expect(value).toEqual({
+          top: [
+            new Change({
+              foo: { other: 'baz' },
+              name: 'zoo'
+            })
+          ]
+        });
+      });
+    });
+  });
+
+  describe('faux arrays at various nestings within an object', () => {
+    describe('faux array deeply nested', () => {
+      it('works with existing changes', () => {
+        const objA = {
+          contact: {
+            emails: {
+              1: new Change({ funEmail: 'fun@email.com', primary: 'primary@email.com' })
+            }
+          }
+        };
+
+        let value = setDeep(objA, 'contact.emails.1.primary', new Change('primary2@email.com'));
+
+        expect(value).toEqual({
+          contact: {
+            emails: {
+              1: new Change({
+                funEmail: 'fun@email.com',
+                primary: 'primary2@email.com'
+              })
+            }
+          }
+        });
+      });
+    });
+  });
+
   it('set with class instances', () => {
     class Person {
       name = 'baz';


### PR DESCRIPTION
Repro of some weird behavior: https://runkit.com/nullvoxpopuli/validated-changeset-with-deep-arrays

![image](https://user-images.githubusercontent.com/199018/107816210-6bdf5680-6d42-11eb-8faa-581a423b959d.png)


I have a complex object with objects as array entries that I'd like to manage with a changeset. :D 

the example I have at work is:

```ts
{
  // big object
  listOfStuff: [
     {
       ... stuff
     },
     {
        ... some stuff
     } 
   ]
}
```

I suppose creating arrays when the property is undefined doesn't really make sense, because you can't know if the user does indeed want an array, or a if they want an object with numbered keys that would behave kinda like an array.

I propose that if a value is an array, we set at indicies, rather than properties on an object