### PR TITLE
Fix lint ci

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,11 @@ module.exports = {
     sourceType:  'module',  // Allows for the use of imports
   },
   rules: {
+    // keep imports / functions, clean, etc,
+    // but allow a fallback when it provides contextual help
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+
+    // disabled rules
     '@typescript-eslint/no-use-before-define': 0,
     '@typescript-eslint/no-empty-function': 0,
     '@typescript-eslint/explicit-function-return-type': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     {
       files: [
         '.eslintrc',
-        'bin/**'
+        'bin/**',
       ],
       parserOptions: {
         sourceType: 'script',
@@ -39,6 +39,14 @@ module.exports = {
       },
       plugins: ['node', 'import'],
       extends: 'plugin:node/recommended',
+    },
+
+    // typescript node files
+    {
+      files: ['rollup.config.ts'],
+      rules: {
+        '@typescript-eslint/no-var-requires' : 'off',
+      }
     },
 
     // bin files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - name: npm install
       run: npm install
     - name: lint js
-      run: npm run lint
+      run: node_modules/.bin/eslint . --ext=js,ts
     - name: test
       run: npm run test
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:all": "npm run test && npm run test-external:ember-changeset && npm run test-external:ember-changeset-validations",
     "test.watch": "jest --watch",
     "test:debug:named": "node --inspect-brk node_modules/.bin/jest --runInBand --watch --testNamePattern",
-    "lint": "eslint .",
+    "lint": "eslint . --ext=js,ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run test && npm run lint",
     "preversion": "npm run lint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,6 @@ import {
   ValidatorAction,
   ValidatorMap
 } from './types';
-import { isArrayObject } from './utils/array-object';
 
 export {
   CHANGESET,

--- a/src/utils/handle-multiple-validations.ts
+++ b/src/utils/handle-multiple-validations.ts
@@ -1,11 +1,5 @@
 import isPromise from './is-promise';
-import {
-  ValidatorMapFunc,
-  ValidationResult,
-  ValidatorAction,
-  ValidatorClass,
-  ValidatorMap
-} from '../types';
+import { ValidatorMapFunc, ValidationResult, ValidatorClass } from '../types';
 
 /**
  * Rejects `true` values from an array of validations. Returns `true` when there

--- a/src/utils/is-object.ts
+++ b/src/utils/is-object.ts
@@ -1,3 +1,8 @@
 export default function isObject<T>(val: T): boolean {
-  return val !== null && typeof val === 'object' && !(val instanceof Date || val instanceof RegExp) && !Array.isArray(val);
+  return (
+    val !== null &&
+    typeof val === 'object' &&
+    !(val instanceof Date || val instanceof RegExp) &&
+    !Array.isArray(val)
+  );
 }

--- a/src/utils/merge-deep.ts
+++ b/src/utils/merge-deep.ts
@@ -1,4 +1,4 @@
-import Change, { getChangeValue, isChange } from '../-private/change';
+import { getChangeValue, isChange } from '../-private/change';
 import normalizeObject from './normalize-object';
 import { isArrayObject, objectToArray, arrayToObject } from './array-object';
 

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -3,7 +3,7 @@ import isObject from './is-object';
 import setDeep from './set-deep';
 import Change, { getChangeValue, isChange } from '../-private/change';
 import normalizeObject from './normalize-object';
-import { objectToArray, arrayToObject, isArrayObject } from './array-object';
+import { objectToArray, arrayToObject } from './array-object';
 import mergeDeep from './merge-deep';
 
 const objectProxyHandler = {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2784,7 +2784,7 @@ describe('Unit | Utility | changeset', () => {
       _validate() {
         return 'oh no';
       }
-      async validate(key: string, newValue: unknown) {
+      async validate(_key: string, _newValue: unknown) {
         return this._validate();
       }
     }
@@ -2815,7 +2815,7 @@ describe('Unit | Utility | changeset', () => {
       _validate() {
         return 'oh no';
       }
-      async validate(key: string, newValue: unknown) {
+      async validate(_key: string, _newValue: unknown) {
         return this._validate();
       }
     }


### PR DESCRIPTION
I asked about this in discord, cause it's weird, unexpected behavior, but: https://discord.com/channels/480462759797063690/483601670685720591/814174406678020120

```bash
validated-changeset on  fix-lint-ci [$!+] is 📦 v0.13.1 via ⬢ v14.15.4 
❯ npm run lint

validated-changeset on  fix-lint-ci [$!+] is 📦 v0.13.1 via ⬢ v14.15.4 
❯ node_modules/.bin/eslint . --ext=js,ts

NullVoxPopuli/validated-changeset/rollup.config.ts
  4:13  error  Require statement not part of import statement  @typescript-eslint/no-var-requires
  ```
  
  not sure why there is a difference. with `yarn`, there is no difference... :shrug: I guess. Maybe an npm upgrade resolves?