### PR TITLE
WIP: Add new util: unwrap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import take from './utils/take';
 import mergeDeep from './utils/merge-deep';
 import setDeep from './utils/set-deep';
 import getDeep, { getSubObject } from './utils/get-deep';
+import { unwrap } from './utils/unwrap';
 
 import {
   Changes,
@@ -61,7 +62,8 @@ export {
   take,
   mergeDeep,
   setDeep,
-  getDeep
+  getDeep,
+  unwrap
 };
 
 const { keys } = Object;

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -130,10 +130,6 @@ class ObjectTreeNode implements ProxyHandler {
 
     return changes;
   }
-
-  toJSON() {
-    return JSON.parse(JSON.stringify(this.unwrap()));
-  }
 }
 
 export { ObjectTreeNode };

--- a/src/utils/unwrap.ts
+++ b/src/utils/unwrap.ts
@@ -1,0 +1,9 @@
+import { ObjectTreeNode } from './object-tree-node';
+
+export function unwrap<Value = Record<string, any>>(valueNode: ObjectTreeNode | Value): Value {
+  if ('unwrap' in valueNode) {
+    return valueNode.unwrap() as Value;
+  }
+
+  return valueNode;
+}

--- a/src/utils/unwrap.ts
+++ b/src/utils/unwrap.ts
@@ -1,8 +1,16 @@
 import { ObjectTreeNode } from './object-tree-node';
 
-export function unwrap<Value = Record<string, any>>(valueNode: ObjectTreeNode | Value): Value {
-  if ('unwrap' in valueNode) {
-    return valueNode.unwrap() as Value;
+export function unwrap<Value = Record<string, any>>(
+  valueNode?: ObjectTreeNode | Value
+): Value | null | undefined {
+  if (!valueNode) {
+    return valueNode;
+  }
+
+  if (typeof valueNode === 'object') {
+    if ('unwrap' in valueNode) {
+      return valueNode.unwrap() as Value;
+    }
   }
 
   return valueNode;

--- a/test/utils/unwrap.test.ts
+++ b/test/utils/unwrap.test.ts
@@ -25,6 +25,16 @@ describe('Unit | Utility | unwrap', () => {
       expect(unwrap(changeset.get('nested.data.value'))).toEqual('bar2');
     });
 
+    it('accesses non-leaf nodes', () => {
+      let changeset = Changeset(data);
+
+      changeset.set('obj.emails.0', 'bar@b.com');
+      changeset.set('nested.data.value', 'bar2');
+
+      expect(unwrap(changeset.get('obj.emails'))).toEqual(['bar@b.com']);
+      expect(unwrap(changeset.get('nested.data'))).toEqual({ value: 'bar2' });
+    });
+
     it('handles deletions', () => {
       let changeset = Changeset(data);
 

--- a/test/utils/unwrap.test.ts
+++ b/test/utils/unwrap.test.ts
@@ -4,21 +4,35 @@ describe('Unit | Utility | unwrap', () => {
   describe('with no changes', () => {
     it('gets the original value', () => {
       let changeset = Changeset({ obj: { emails: ['foo@a.com'] } });
-      let actual = unwrap(changeset.get('obj.emails'));
 
-      expect(actual).toEqual(['foo@a.com']);
+      expect(unwrap(changeset.get('obj.emails'))).toEqual(['foo@a.com']);
     });
   });
 
   describe('with changes to the leaf data', () => {
+    const data = Object.freeze({
+      obj: { emails: ['foo@a.com'] },
+      nested: { data: { value: 'bar' } }
+    });
+
     it('gets a preview of the value', () => {
-      let changeset = Changeset({ obj: { emails: ['foo@a.com'] } });
+      let changeset = Changeset(data);
 
       changeset.set('obj.emails.0', 'bar@b.com');
+      changeset.set('nested.data.value', 'bar2');
 
-      let actual = unwrap(changeset.get('obj.emails'));
+      expect(unwrap(changeset.get('obj.emails.0'))).toEqual('bar@b.com');
+      expect(unwrap(changeset.get('nested.data.value'))).toEqual('bar2');
+    });
 
-      expect(actual).toEqual(['bar@b.com']);
+    it('handles deletions', () => {
+      let changeset = Changeset(data);
+
+      changeset.set('obj.emails.0', null);
+      changeset.set('nested.data.value', null);
+
+      expect(unwrap(changeset.get('obj.emails.0'))).toEqual(null);
+      expect(unwrap(changeset.get('nested.data.value'))).toEqual(null);
     });
   });
 });

--- a/test/utils/unwrap.test.ts
+++ b/test/utils/unwrap.test.ts
@@ -1,0 +1,24 @@
+import { Changeset, unwrap } from '../../src';
+
+describe('Unit | Utility | unwrap', () => {
+  describe('with no changes', () => {
+    it('gets the original value', () => {
+      let changeset = Changeset({ obj: { emails: ['foo@a.com'] } });
+      let actual = unwrap(changeset.get('obj.emails'));
+
+      expect(actual).toEqual(['foo@a.com']);
+    });
+  });
+
+  describe('with changes to the leaf data', () => {
+    it('gets a preview of the value', () => {
+      let changeset = Changeset({ obj: { emails: ['foo@a.com'] } });
+
+      changeset.set('obj.emails.0', 'bar@b.com');
+
+      let actual = unwrap(changeset.get('obj.emails'));
+
+      expect(actual).toEqual(['bar@b.com']);
+    });
+  });
+});


### PR DESCRIPTION
Goals:
 - get the current preview of data + changes, no matter what value path we've accessed
   - supports the use case where you may want to preview changed data live as your editing it, and accessing non-leaf nodes for iteration purposes (as in rendering a JSON object with fancy instrumentation or something, or dynamic form elements based on the shape of data, etc)