### PR TITLE
Support null merging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { buildOldValues } from './utils/build-old-values';
 import { ObjectTreeNode } from './utils/object-tree-node';
 import objectWithout from './utils/object-without';
 import take from './utils/take';
-import mergeDeep from './utils/merge-deep';
+import mergeDeep, { propertyIsUnsafe } from './utils/merge-deep';
 import setDeep from './utils/set-deep';
 import getDeep, { getSubObject } from './utils/get-deep';
 import { objectToArray, arrayToObject } from './utils/array-object';
@@ -61,7 +61,8 @@ export {
   take,
   mergeDeep,
   setDeep,
-  getDeep
+  getDeep,
+  propertyIsUnsafe
 };
 
 const { keys } = Object;

--- a/src/utils/merge-deep.ts
+++ b/src/utils/merge-deep.ts
@@ -164,8 +164,9 @@ export default function mergeDeep(
     return source;
   } else if (sourceIsArray) {
     return source;
-  } else if (target === null) {
+  } else if (target === null || target === undefined) {
     // typeof null === 'object'
+    // typeof undefined === 'undefined'
     return source;
   } else {
     return mergeTargetAndSource(target, source, options);

--- a/src/utils/merge-deep.ts
+++ b/src/utils/merge-deep.ts
@@ -164,6 +164,9 @@ export default function mergeDeep(
     return source;
   } else if (sourceIsArray) {
     return source;
+  } else if (target === null) {
+    // typeof null === 'object'
+    return source;
   } else {
     return mergeTargetAndSource(target, source, options);
   }

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -88,6 +88,9 @@ export default function setDeep(
 
         let newValue;
 
+        // if the resolved value was deleted (via setting to null or undefined),
+        // there is no need to setDeep. We can short-circuit that and set
+        // newValue directly because of the shallow value
         if (isArrayLike && !resolvedValue) {
           newValue = resolvedValue;
         } else {

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -80,12 +80,19 @@ export default function setDeep(
         const siblings = findSiblings(changeValue, keys);
 
         const resolvedValue = isChange(value) ? getChangeValue(value) : value;
-        const nestedKeys =
-          Array.isArray(target) || isArrayObject(target)
-            ? keys.slice(i + 1, keys.length).join('.') // remove first key segment as well as the index
-            : keys.slice(1, keys.length).join('.'); // remove first key segment
 
-        const newValue = setDeep(siblings, nestedKeys, resolvedValue, options);
+        const isArrayLike = Array.isArray(target) || isArrayObject(target);
+        const nestedKeys = isArrayLike
+          ? keys.slice(i + 1, keys.length).join('.') // remove first key segment as well as the index
+          : keys.slice(1, keys.length).join('.'); // remove first key segment
+
+        let newValue;
+
+        if (isArrayLike && !resolvedValue) {
+          newValue = resolvedValue;
+        } else {
+          newValue = setDeep(siblings, nestedKeys, resolvedValue, options);
+        }
 
         target[prop] = new Change(newValue);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -933,6 +933,12 @@ describe('Unit | Utility | changeset', () => {
         expect(changeset.get('contacts')).toEqual([sanHolo, fred]);
         expect(changeset.get('contacts.0.emails.primary')).toEqual('sanholo@email.com');
         expect(changeset.changes).toEqual([{ key: 'contacts.0', value: sanHolo }]);
+
+        changeset.set('contacts.0', null);
+
+        expect(changeset.get('contacts.0')).toEqual(null);
+        expect(changeset.get('contacts')).toEqual([null, fred]);
+        expect(changeset.changes).toEqual([{ key: 'contacts.0', value: null }]);
       });
 
       xit(`negative values are not allowed`, () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -938,7 +938,6 @@ describe('Unit | Utility | changeset', () => {
         expect(changeset.get('contacts.0.emails.primary')).toEqual('sanholo@email.com');
         expect(changeset.changes).toEqual([{ key: 'contacts.0', value: sanHolo }]);
 
-        debugger;
         // "Delete" array element again
         changeset.set('contacts.0', null);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -908,6 +908,33 @@ describe('Unit | Utility | changeset', () => {
         ]);
       });
 
+      it('can add an item to an index in an array where that item was previously removed', () => {
+        const deepObj = (email: string) => ({
+          emails: {
+            primary: email
+          }
+        });
+        const bob = deepObj('bob@email.com');
+        const fred = deepObj('fred@email.com');
+        const sanHolo = deepObj('sanholo@email.com');
+
+        const changeset = Changeset({
+          contacts: [bob, fred]
+        });
+
+        changeset.set('contacts.0', null);
+
+        expect(changeset.get('contacts.0')).toEqual(null);
+        expect(changeset.get('contacts')).toEqual([null, fred]);
+        expect(changeset.changes).toEqual([{ key: 'contacts.0', value: null }]);
+
+        changeset.set('contacts.0', sanHolo);
+
+        expect(changeset.get('contacts')).toEqual([sanHolo, fred]);
+        expect(changeset.get('contacts.0.emails.primary')).toEqual('sanholo@email.com');
+        expect(changeset.changes).toEqual([{ key: 'contacts.0', value: sanHolo }]);
+      });
+
       xit(`negative values are not allowed`, () => {
         // This test is currently disabled because setDeep doesn't have a reference to the
         // original array and setDeep is where we'd throw on invalid key values

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -924,12 +924,14 @@ describe('Unit | Utility | changeset', () => {
 
         changeset.set('contacts.0', null);
 
+        expect(changeset.isDirty).toBeTruthy();
         expect(changeset.get('contacts.0')).toEqual(null);
         expect(changeset.get('contacts')).toEqual([null, fred]);
         expect(changeset.changes).toEqual([{ key: 'contacts.0', value: null }]);
 
         changeset.set('contacts.0', sanHolo);
 
+        expect(changeset.isDirty).toBeTruthy();
         expect(changeset.get('contacts')).toEqual([sanHolo, fred]);
         expect(changeset.get('contacts.0.emails.primary')).toEqual('sanholo@email.com');
         expect(changeset.changes).toEqual([{ key: 'contacts.0', value: sanHolo }]);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -938,12 +938,20 @@ describe('Unit | Utility | changeset', () => {
         expect(changeset.get('contacts.0.emails.primary')).toEqual('sanholo@email.com');
         expect(changeset.changes).toEqual([{ key: 'contacts.0', value: sanHolo }]);
 
+        debugger;
         // "Delete" array element again
         changeset.set('contacts.0', null);
 
+        expect(changeset.isDirty).toBeTruthy();
         expect(changeset.get('contacts.0')).toEqual(null);
         expect(changeset.get('contacts')).toEqual([null, fred]);
         expect(changeset.changes).toEqual([{ key: 'contacts.0', value: null }]);
+
+        // Revert everything
+        changeset.rollback();
+        expect(changeset.isDirty).toBeFalsy();
+        expect(changeset.changes).toEqual([]);
+        expect(changeset.get('contacts')).toEqual([bob, fred]);
       });
 
       xit(`negative values are not allowed`, () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -922,6 +922,7 @@ describe('Unit | Utility | changeset', () => {
           contacts: [bob, fred]
         });
 
+        // "Delete" array element
         changeset.set('contacts.0', null);
 
         expect(changeset.isDirty).toBeTruthy();
@@ -929,6 +930,7 @@ describe('Unit | Utility | changeset', () => {
         expect(changeset.get('contacts')).toEqual([null, fred]);
         expect(changeset.changes).toEqual([{ key: 'contacts.0', value: null }]);
 
+        // Set array element to entirely new object
         changeset.set('contacts.0', sanHolo);
 
         expect(changeset.isDirty).toBeTruthy();
@@ -936,6 +938,7 @@ describe('Unit | Utility | changeset', () => {
         expect(changeset.get('contacts.0.emails.primary')).toEqual('sanholo@email.com');
         expect(changeset.changes).toEqual([{ key: 'contacts.0', value: sanHolo }]);
 
+        // "Delete" array element again
         changeset.set('contacts.0', null);
 
         expect(changeset.get('contacts.0')).toEqual(null);

--- a/test/utils/merge-deep.test.ts
+++ b/test/utils/merge-deep.test.ts
@@ -57,7 +57,7 @@ describe('Unit | Utility | merge deep', () => {
     const value = mergeDeep(null, objB);
 
     expect(value).toEqual({ employees: ['Ivan'] });
-  })
+  });
 
   it('it works with classes', () => {
     class Employee {

--- a/test/utils/merge-deep.test.ts
+++ b/test/utils/merge-deep.test.ts
@@ -59,6 +59,14 @@ describe('Unit | Utility | merge deep', () => {
     expect(value).toEqual({ employees: ['Ivan'] });
   });
 
+  it('overrides undefined', () => {
+    const objB = { employees: ['Ivan'] };
+
+    const value = mergeDeep(undefined, objB);
+
+    expect(value).toEqual({ employees: ['Ivan'] });
+  });
+
   it('it works with classes', () => {
     class Employee {
       names = [];

--- a/test/utils/merge-deep.test.ts
+++ b/test/utils/merge-deep.test.ts
@@ -51,6 +51,18 @@ describe('Unit | Utility | merge deep', () => {
     expect(value).toEqual({ employees: [null] });
   });
 
+  it('removes from deep array data', () => {
+    const objA = {
+      employees: [{ email: 'a@email.com' }, { email: 'b@email.com' }, { email: 'c@email.com' }]
+    };
+    const objB = { employees: { 2: new Change(undefined) } };
+    const value = mergeDeep(objA, objB);
+
+    expect(value).toEqual({
+      employees: [{ email: 'a@email.com' }, { email: 'b@email.com' }, undefined]
+    });
+  });
+
   it('overrides null', () => {
     const objB = { employees: ['Ivan'] };
 

--- a/test/utils/merge-deep.test.ts
+++ b/test/utils/merge-deep.test.ts
@@ -51,6 +51,14 @@ describe('Unit | Utility | merge deep', () => {
     expect(value).toEqual({ employees: [null] });
   });
 
+  it('overrides null', () => {
+    const objB = { employees: ['Ivan'] };
+
+    const value = mergeDeep(null, objB);
+
+    expect(value).toEqual({ employees: ['Ivan'] });
+  })
+
   it('it works with classes', () => {
     class Employee {
       names = [];

--- a/test/utils/set-deep.test.ts
+++ b/test/utils/set-deep.test.ts
@@ -179,12 +179,20 @@ describe('Unit | Utility | set deep', () => {
 
   it('sets changes to undefined values', () => {
     const objA = {
-      contacts: { 0: new Change({ emails: { primary: 'sanholo@email.com' } }) }
+      contacts: {
+        0: new Change({ emails: { primary: 'sanholo@email.com' } }),
+        1: { emails: { primary: 'fred@email.com' } }
+      }
     };
     let value = setDeep(objA, 'contacts.0', new Change(null));
 
     expect(value).toEqual({
-      contacts: { 0: new Change(null) }
+      contacts: {
+        0: new Change(null),
+        1: {
+          emails: { primary: 'fred@email.com' }
+        }
+      }
     });
   });
 

--- a/test/utils/set-deep.test.ts
+++ b/test/utils/set-deep.test.ts
@@ -177,6 +177,17 @@ describe('Unit | Utility | set deep', () => {
     });
   });
 
+  it('sets changes to undefined values', () => {
+    const objA = {
+      contacts: { 0: new Change({ emails: { primary: 'sanholo@email.com' } }) }
+    };
+    let value = setDeep(objA, 'contacts.0', new Change(null));
+
+    expect(value).toEqual({
+      contacts: { 0: new Change(null) }
+    });
+  });
+
   it('it works with nested Changes with different order', () => {
     const objA = {
       top: new Change({ foo: { other: 'bar' }, name: 'jimmy' })


### PR DESCRIPTION
why is `typeof null === 'object'`?
silly JS

     * If the target was set to null or undefined, we always want to return the source.
     * There is nothing to merge.
     *
     * Without this explicit check, typeof null === typeof {any object-like thing}
     * which means that mergeTargetAndSource will be called, and you can't merge with null
