### PR TITLE
[Bug]: setDeep does not respect re-setting top level Change object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -835,7 +835,7 @@ export class BufferedChangeset implements IChangeset {
     let changes: Changes = this[CHANGES];
 
     // Happy path: update change map.
-    if (oldValue !== value) {
+    if (oldValue !== value || oldValue === undefined) {
       // @tracked
       let result: Changes = this.setDeep(changes, key, new Change(value), {
         safeSet: this.safeSet

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -99,6 +99,9 @@ export default function setDeep(
         // newValue directly because of the shallow value
         if (isArrayLike && !resolvedValue) {
           newValue = resolvedValue;
+        } else if (i === keys.length - 1) {
+          // If last key, this is the final value
+          newValue = resolvedValue;
         } else {
           newValue = setDeep(siblings, nestedKeys, resolvedValue, options);
         }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -799,6 +799,62 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyChangeset.change).toEqual({ age: '90' });
   });
 
+  test('#set Ember.set with Object actually does work TWICE for nested', () => {
+    set(dummyModel, 'name', {});
+    let title1 = { id: 'Mr', description: 'Mister' };
+    let title2 = { id: 'Mrs', description: 'Missus' };
+    let dummyChangeset: any = Changeset(dummyModel);
+    set(dummyChangeset, 'name.title', title1);
+
+    expect(get(dummyModel, 'name.title.id')).toBeUndefined();
+    expect(dummyChangeset.name.title.id).toEqual('Mr');
+    expect(dummyChangeset.get('name.title.id')).toEqual('Mr');
+
+    let changes = get(dummyChangeset, 'changes');
+    expect(changes).toEqual([{ key: 'name.title', value: title1 }]);
+
+    set(dummyChangeset, 'name.title', title2);
+
+    expect(get(dummyModel, 'name.title.id')).toBeUndefined();
+    expect(dummyChangeset.name.title.id).toEqual('Mrs');
+    expect(dummyChangeset.get('name.title.id')).toEqual('Mrs');
+
+    changes = get(dummyChangeset, 'changes');
+    expect(changes).toEqual([{ key: 'name.title', value: title2 }]);
+
+    dummyChangeset.execute();
+
+    expect(dummyModel.name.title.id).toEqual('Mrs');
+  });
+
+  test('#set with Object should work TWICE for nested', () => {
+    set(dummyModel, 'name', {});
+    let title1 = { id: 'Mr', description: 'Mister' };
+    let title2 = { id: 'Mrs', description: 'Missus' };
+    let dummyChangeset: any = Changeset(dummyModel);
+    dummyChangeset.set('name.title', title1);
+
+    expect(get(dummyModel, 'name.title.id')).toBeUndefined();
+    expect(dummyChangeset.name.title.id).toEqual('Mr');
+    expect(dummyChangeset.get('name.title.id')).toEqual('Mr');
+
+    let changes = dummyChangeset.changes;
+    expect(changes).toEqual([{ key: 'name.title', value: title1 }]);
+
+    dummyChangeset.set('name.title', title2);
+
+    expect(get(dummyModel, 'name.title.id')).toBeUndefined();
+    expect(dummyChangeset.name.title.id).toEqual('Mrs');
+    expect(dummyChangeset.get('name.title.id')).toEqual('Mrs');
+
+    changes = dummyChangeset.changes;
+    expect(changes).toEqual([{ key: 'name.title', value: title2 }]);
+
+    dummyChangeset.execute();
+
+    expect(dummyModel.name.title.id).toEqual('Mrs');
+  });
+
   describe('arrays within nested objects', () => {
     describe('#set', () => {
       let initialData: { contact: { emails?: string[] } } = { contact: { emails: [] } };


### PR DESCRIPTION
The issue here is we were mutating a nested `set` incorrectly once we reached the leaf key.  This caused bugs as shown in the tests.

ref https://github.com/poteto/ember-changeset/issues/592