### PR TITLE
Support setting properties to false

### DIFF
--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -16,15 +16,10 @@ const objectProxyHandler = {
       return;
     }
 
-    let childValue;
+    let childValue = node.safeGet(node.changes, key);
 
-    let changeValue = node.safeGet(node.changes, key);
-    if (changeValue) {
-      if (isChange(changeValue)) {
-        return getChangeValue(changeValue);
-      }
-
-      childValue = changeValue;
+    if (isChange(childValue)) {
+      return getChangeValue(childValue);
     }
 
     if (isObject(childValue)) {

--- a/src/utils/set-deep.ts
+++ b/src/utils/set-deep.ts
@@ -97,7 +97,7 @@ export default function setDeep(
         // if the resolved value was deleted (via setting to null or undefined),
         // there is no need to setDeep. We can short-circuit that and set
         // newValue directly because of the shallow value
-        if (isArrayLike && !resolvedValue) {
+        if (isArrayLike && undefined === resolvedValue) {
           newValue = resolvedValue;
         } else if (i === keys.length - 1) {
           // If last key, this is the final value

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -863,6 +863,21 @@ describe('Unit | Utility | changeset', () => {
         initialData = { contact: { emails: ['bob@email.com'] } };
       });
 
+      it('works with boolean values', () => {
+        let initialData = { contact: { emails: [{}, {}] } };
+
+        const changeset = Changeset(initialData);
+
+        changeset.set('contact.emails.2', { nested: false });
+        expect(changeset.get('contact.emails.2')).toEqual({ nested: false });
+
+        changeset.set('contact.emails.2.nested', true);
+        expect(changeset.get('contact.emails.2')).toEqual({ nested: true });
+
+        changeset.set('contact.emails.2.nested', false);
+        expect(changeset.get('contact.emails.2')).toEqual({ nested: false });
+      });
+
       it('nested objects cannot create arrays when we have no hints', () => {
         initialData.contact = {};
 

--- a/test/utils/set-deep.test.ts
+++ b/test/utils/set-deep.test.ts
@@ -30,6 +30,17 @@ describe('Unit | Utility | set deep', () => {
     expect(value).toEqual({ name: { other: null, nick: null } });
   });
 
+  it('handles booleans', () => {
+    const objA = { name: [{ nick: false }] };
+    const value = setDeep(objA, 'name.0.nick', true);
+
+    expect(value).toEqual({ name: [{ nick: true }] });
+
+    const value2 = setDeep(value, 'name.0.nick', false);
+
+    expect(value2).toEqual({ name: [{ nick: false }] });
+  });
+
   it('handles function case', () => {
     const objA = { name: { other: 'Ivan' } };
     const anon = () => {};


### PR DESCRIPTION
in Collaboration with @basandlin and @camskene  :tada: 

We ran in to an issue where `changeset.set('propertyPathin.A.NewlyCreated.Object', false)` would delete the newly created object.
Tests added to verify :heart: 