### PR TITLE
Rework final phases of get trap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -314,6 +314,14 @@ export class BufferedChangeset implements IChangeset {
   /**
    * String representation for the changeset.
    */
+  get [Symbol.toStringTag](): string {
+    let normalisedContent: object = pureAssign(this[CONTENT], {});
+    return `changeset:${normalisedContent.toString()}`;
+  }
+
+  /**
+   * String representation for the changeset.
+   */
   toString(): string {
     let normalisedContent: object = pureAssign(this[CONTENT], {});
     return `changeset:${normalisedContent.toString()}`;
@@ -976,11 +984,6 @@ export class BufferedChangeset implements IChangeset {
       }
     }
 
-    // return getters/setters/methods on BufferedProxy instance
-    if (baseKey in this || key in this) {
-      return this.getDeep(this, key);
-    }
-
     const subContent = this.maybeUnwrapProxy(this.getDeep(content, key));
     if (this.isObject(subContent)) {
       let subChanges = this.getDeep(changes, key);
@@ -1012,6 +1015,20 @@ export class BufferedChangeset implements IChangeset {
       }
 
       return subChanges;
+    }
+
+    // avoid toString on any generic object
+    if (key === 'toString') {
+      return this.toString;
+    }
+
+    if (subContent === undefined) {
+      // return getters/setters/methods on BufferedProxy instance
+      if (baseKey in this || key in this) {
+        let thisVal = this.getDeep(this, key);
+
+        return thisVal;
+      }
     }
 
     return subContent;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -672,6 +672,26 @@ describe('Unit | Utility | changeset', () => {
     expect(cat.color).toEqual('red');
   });
 
+  it('#get works with toString override', () => {
+    dummyModel.toString = function() {
+      return 'mine';
+    };
+    const dummyChangeset = Changeset(dummyModel);
+    dummyChangeset['name'] = undefined;
+    const result = dummyChangeset.toString();
+
+    expect(result).toEqual('changeset:mine');
+  });
+
+  it('#get prioritizes own methods/getters', () => {
+    dummyModel.trigger = function(arg: any) {
+      expect(arg).toEqual('mine');
+    };
+    const dummyChangeset = Changeset(dummyModel);
+    dummyChangeset['name'] = undefined;
+    dummyChangeset.trigger('mine');
+  });
+
   /**
    * #set
    */
@@ -1729,6 +1749,8 @@ describe('Unit | Utility | changeset', () => {
   });
 
   it('#set works after save', () => {
+    delete dummyModel.save;
+
     dummyModel['org'] = {
       usa: {
         mn: 'mn',
@@ -1845,11 +1867,12 @@ describe('Unit | Utility | changeset', () => {
   });
 
   it('it accepts async validations', async () => {
+    delete dummyModel.save;
     const dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations));
     const expectedChanges = [{ key: 'async', value: true }];
     const expectedError = { async: { validation: 'is invalid', value: 'is invalid' } };
 
-    await dummyChangeset.set('async', true);
+    dummyChangeset.set('async', true);
     expect(dummyChangeset.changes).toEqual(expectedChanges);
 
     dummyChangeset.set('async', 'is invalid');
@@ -2214,7 +2237,7 @@ describe('Unit | Utility | changeset', () => {
     expect(result).toBeUndefined();
     const promise = dummyChangeset.save({ foo: 'test options' });
     expect(result).toEqual('ok');
-    expect(dummyChangeset.change).toEqual({});
+    expect(dummyChangeset.change).toEqual({ name: 'foo' });
     expect(options).toEqual({ foo: 'test options' });
     expect(!!promise && typeof promise.then === 'function').toBeTruthy();
     promise
@@ -2376,6 +2399,7 @@ describe('Unit | Utility | changeset', () => {
   });
 
   it('#merge preserves content and validator of origin changeset', async () => {
+    delete dummyModel.save;
     let dummyChangesetA = Changeset(dummyModel, lookupValidator(dummyValidations));
     let dummyChangesetB = Changeset(dummyModel);
     let dummyChangesetC = dummyChangesetA.merge(dummyChangesetB);


### PR DESCRIPTION
This PR prioritizes user data over Proxy instance getters/methods.

Currently, if a user has a method named `trigger` defined on their "model" (argument to Changeset), then it will be ignored in favor of the Changeset `trigger` method.  To ensure class based inheritance works as expected, we need to adjust the Proxy trap prioritization order.

1. Changes
2. Content
3. Changeset properties.

ref #122 