### PR TITLE
Allow a changeset to be created in a validated state

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 ## Full API
 
 ```js
-Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: boolean, changesetKeys: string[] });
+Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: boolean, initValidate: boolean, changesetKeys: string[] });
 ```
 
 - `model` (required)
@@ -68,6 +68,8 @@ Changeset(model, lookupValidator(validationMap), validationMap, { skipValidate: 
     > note: `validationMap` might not be inclusive of all keys that can be set on an object.
 
 - `changesetKeys` (optional) - will ensure your changeset and related `isDirty` state is contained to a specific enum of keys.  If a key that is not in `changesetKeys` is set on the changeset, it will not dirty the changeset.
+
+- `initValidate` (optional) - will run the validations and set the validation state when the changeset is created. This option does not support async validations.
 
 ## Examples
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export interface ProxyHandler {
 
 export type Config = {
   skipValidate?: boolean;
+  initValidate?: boolean;
   changesetKeys?: string[];
 };
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -242,6 +242,54 @@ describe('Unit | Utility | changeset', () => {
   /**
    * #isValid
    */
+  it('does not validate with default options', () => {
+    const dummyChangeset = Changeset(
+      dummyModel,
+      lookupValidator(dummyValidations),
+      dummyValidations,
+      {}
+    );
+
+    expect(dummyChangeset.get('isValid')).toBeTruthy();
+  });
+
+  it('does not validate when the initValidate option is set to false', () => {
+    const dummyChangeset = Changeset(
+      dummyModel,
+      lookupValidator(dummyValidations),
+      dummyValidations,
+      { initValidate: false }
+    );
+
+    expect(dummyChangeset.get('isValid')).toBeTruthy();
+  });
+
+  it('validates when the initValidate option is set to true', () => {
+    const dummyChangeset = Changeset(
+      dummyModel,
+      lookupValidator(dummyValidations),
+      dummyValidations,
+      { initValidate: true }
+    );
+
+    expect(dummyChangeset.get('isValid')).toBeFalsy();
+  });
+
+  it('validates when the initValidate option is set to true and the initial changeset data is valid', () => {
+    dummyModel.name = 'Bobby';
+
+    let validations: Record<string, any> = {
+      name(_k: string, value: any) {
+        return (!!value && value.length > 3) || 'too short';
+      }
+    };
+
+    const dummyChangeset = Changeset(dummyModel, lookupValidator(validations), validations, {
+      initValidate: true
+    });
+
+    expect(dummyChangeset.get('isValid')).toBeTruthy();
+  });
 
   /**
    * #isInvalid


### PR DESCRIPTION
Adds an `initValidate` changeset option that can be specified when creating an instance of a changeset. When this option is `true`, the changeset will be validated immediately upon creation.

The idea behind this feature is to support the use case where a form needs to start in an invalid state.

For example, we regularly do the following in the ember apps that I work on.

```js
constructor() {
  super(...arguments);

  this.changeset = new Changeset(
    this.args.someModel,
    lookupValidator(SomeValidations),
    SomeValidations
  );
  this.changeset.validate()
}
```

However, this code no longer works in Ember 3.24.0 and above because it can require mutating the changeset `_errors` property multiple times within the same computation.

This will cause the following error.

<img width="777" alt="Screenshot 2021-12-09 at 16 32 36" src="https://user-images.githubusercontent.com/4869877/145852110-78f8fbac-7468-437c-979f-e4020320c6a1.png">

Using the `initValidate: true` option, we can now remove the call to `.validate()` and still achieve the same result as the original code without causing multiple mutations of the underlying data.

The example above would now look like this.

```js
constructor() {
  super(...arguments);

  this.changeset = new Changeset(
    this.args.someModel,
    lookupValidator(SomeValidations),
    SomeValidations,
    { initValidate: true }
  );
}
```

At this point the changeset will have run all specified validations and the `_errors` property will be populated with any failing validations.

---

There was a previous approach at supporting this feature upstream in the ember changeset libraries (see https://github.com/poteto/ember-changeset/issues/451) and this PR takes its inspiration from there. However, this implementation is much lower level due the new state management constraints in modern Ember, as mentioned above.

One caveat I wanted to highlight is the lack of support for async validations when using the `initValidate` option. I spent some time looking into this and I now believe that it's not possible to support these. This is because the validations are occurring within the constructor, which does not expect to deal with side effects or asynchrous operations. If this exclusion is acceptable, would it make sense to throw an exception when an async validation is detected?