### PR TITLE
Return falsy properties values

### DIFF
--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -42,7 +42,7 @@ const objectProxyHandler = {
       return childValue;
     } else if (node.content) {
       const nodeContent = node.content;
-      if (node.safeGet(nodeContent, key)) {
+      if (node.safeGet(nodeContent, key) !== undefined) {
         return node.safeGet(nodeContent, key);
       }
     }

--- a/test/utils/object-tree-node.test.ts
+++ b/test/utils/object-tree-node.test.ts
@@ -69,4 +69,16 @@ describe('Unit | Utility | object tree node', () => {
     expect(result.changes).toEqual({});
     expect(result.proxy.foo).toBe('foo');
   });
+
+  it('it returns falsy values', () => {
+    const result = new ObjectTreeNode({}, { name: '', flag: false, count: 0, ref: null });
+
+    expect(result.proxy.name).toBe('');
+    expect(result.proxy.flag).toBe(false);
+    expect(result.proxy.count).toBe(0);
+    expect(result.proxy.ref).toBe(null);
+
+    // backward compatibility - unknown properties should still resolve to undefined
+    expect(result.proxy.nonExistentProperty).toBe(undefined);
+  });
 });


### PR DESCRIPTION
Previously the proxy only returned truthy values for the properties
and `undefined` otherwise.
- Fix this to return the original values