### PR TITLE
Fix restore method to work with nested keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -686,10 +686,7 @@ export class BufferedChangeset implements IChangeset {
    * @method restore
    */
   restore({ changes, errors }: Snapshot): this {
-    let newChanges: Changes = keys(changes).reduce((newObj: Changes, key: keyof Changes) => {
-      newObj[key] = new Change(changes[key]);
-      return newObj;
-    }, {});
+    let newChanges: Changes = this.getChangesFromSnapshot(changes);
 
     let newErrors: Errors<any> = keys(errors).reduce((newObj: Errors<any>, key: keyof Changes) => {
       let e: IErr<any> = errors[key];
@@ -705,6 +702,24 @@ export class BufferedChangeset implements IChangeset {
 
     this._notifyVirtualProperties();
     return this;
+  }
+
+  private getChangesFromSnapshot(changes: Changes) {
+    return keys(changes).reduce((newObj, key) => {
+      newObj[key] = this.getChangeForProp(changes[key]);
+      return newObj;
+    }, {} as Changes)
+  }
+
+  private getChangeForProp(value: any) {
+    if (!isObject(value)) {
+      return new Change(value);
+    }
+
+    return keys(value).reduce((newObj, key) => {
+      newObj[key] = this.getChangeForProp(value[key]);
+      return newObj;
+    }, {} as Changes)
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -708,7 +708,7 @@ export class BufferedChangeset implements IChangeset {
     return keys(changes).reduce((newObj, key) => {
       newObj[key] = this.getChangeForProp(changes[key]);
       return newObj;
-    }, {} as Changes)
+    }, {} as Changes);
   }
 
   private getChangeForProp(value: any) {
@@ -719,7 +719,7 @@ export class BufferedChangeset implements IChangeset {
     return keys(value).reduce((newObj, key) => {
       newObj[key] = this.getChangeForProp(value[key]);
       return newObj;
-    }, {} as Changes)
+    }, {} as Changes);
   }
 
   /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3223,6 +3223,10 @@ describe('Unit | Utility | changeset', () => {
 
     expect(changeset.get('name')).toBe('Jim Bob');
     expect(changeset.get('address.country')).toBe('North Korea');
+    expect(changeset.changes).toEqual([
+      { key: 'name', value: 'Jim Bob' },
+      { key: 'address.country', value: 'North Korea' }
+    ]);
   });
 
   /**


### PR DESCRIPTION
restore method converted snapshot with nested keys
```
{
  changes: { name: 'Jim Bob', address: { country: 'North Korea' } },
  errors: {}
}
```
into changeset with changes like below
```
[
  { key: 'name', value: 'Jim Bob' },
  { key: 'address', value: { country: 'North Korea' } }
]
```
fixed it to be:
```
[
  { key: 'name', value: 'Jim Bob' },
  { key: 'address.country', value: 'North Korea' }
]
```