### PR TITLE
ValidationChangeset with yup compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -172,6 +172,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
@@ -625,6 +634,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.180",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+      "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==",
       "dev": true
     },
     "@types/node": {
@@ -2882,7 +2897,6 @@
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3087,8 +3101,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3178,8 +3191,7 @@
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -4887,6 +4899,12 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -5108,6 +5126,12 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5578,6 +5602,12 @@
         "sisteransi": "^1.0.3"
       }
     },
+    "property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==",
+      "dev": true
+    },
     "psl": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
@@ -5641,6 +5671,12 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -6567,6 +6603,12 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -7002,6 +7044,29 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "ts-jest": "^24.2.0",
-    "typescript": "^3.8.0"
+    "typescript": "^3.8.0",
+    "yup": "^0.32.11"
   },
-  "dependencies": {}
+  "volta": {
+    "node": "14.19.1"
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,11 @@ export interface ValidatorClass {
   [s: string]: any;
 }
 
+export interface ValidatorKlass {
+  validate: () => any;
+  [s: string]: any;
+}
+
 export type ValidatorMap =
   | { [s: string]: ValidatorMapFunc | ValidatorMapFunc[] | any }
   | null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,7 +57,7 @@ export interface ValidatorClass {
 }
 
 export interface ValidatorKlass {
-  validate: () => any;
+  validate: (obj: any) => any;
   [s: string]: any;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,11 +56,6 @@ export interface ValidatorClass {
   [s: string]: any;
 }
 
-export interface ValidatorKlass {
-  validate: (obj: any) => any;
-  [s: string]: any;
-}
-
 export type ValidatorMap =
   | { [s: string]: ValidatorMapFunc | ValidatorMapFunc[] | any }
   | null

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -451,6 +451,15 @@ export class ValidatedChangeset {
   }
 
   /**
+   * @method removeError
+   */
+  removeErrors() {
+    // @tracked
+    this[ERRORS] = {};
+    this[ERRORS_CACHE] = this[ERRORS];
+  }
+
+  /**
    * Manually push multiple errors to the changeset as an array.
    * key maybe in form 'name.short' so need to go deep
    *

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -386,11 +386,6 @@ export class ValidatedChangeset {
   }
 
   /**
-   * Validates the changeset immediately against the validationMap passed in.
-   * If no key is passed into this method, it will validate all fields on the
-   * validationMap and set errors accordingly. Will throw an error if no
-   * validationMap is present.
-   *
    * @method validate
    */
   async validate(): Promise<any> {
@@ -399,6 +394,16 @@ export class ValidatedChangeset {
 
     return this.Validator.validate({ ...normalizeObject(content), ...normalizeObject(changes) });
   }
+
+  /**
+   * @method validateSync
+   */
+     async validateSync(): Promise<any> {
+      const changes = this[CHANGES];
+      const content = this[CONTENT];
+  
+      return this.Validator.validateSync({ ...normalizeObject(content), ...normalizeObject(changes) }, { abortEarly: false });
+    }
 
   /**
    * Manually add an error to the changeset. If there is an existing
@@ -429,6 +434,18 @@ export class ValidatedChangeset {
 
     // Return passed-in `error`.
     return newError;
+  }
+
+  /**
+   * @method removeError
+   */
+  removeError<T>(key: string) {
+    // Remove `key` to errors map.
+    let errors: Errors<any> = this[ERRORS];
+    // @tracked
+    this[ERRORS] = this.setDeep(errors, key, null, { safeSet: this.safeSet });
+    this[ERRORS] = this._deleteKey(ERRORS, key) as Errors<any>;
+    this[ERRORS_CACHE] = this[ERRORS];
   }
 
   /**

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -73,7 +73,7 @@ export function newFormat(
 }
 
 // This is intended to provide an alternative changeset structure compatible with `yup`
-// This slims down the set of features, including removed APIs and `validate` returns just the `validate()` method call and requires users to manually add errors.
+// This slims down the set of features, including removed APIs and `validate` returns just the `validate(obj)` method call and requires users to manually add errors.
 export class ValidatedChangeset {
   constructor(obj: object, public Validator: ValidatorKlass, options: Config = {}) {
     this[CONTENT] = obj;
@@ -394,7 +394,9 @@ export class ValidatedChangeset {
    * @method validate
    */
   async validate(): Promise<any> {
-    return this.Validator.validate();
+    const changes = this[CHANGES];
+
+    return this.Validator.validate(normalizeObject(changes));
   }
 
   /**

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -398,12 +398,15 @@ export class ValidatedChangeset {
   /**
    * @method validateSync
    */
-     async validateSync(): Promise<any> {
-      const changes = this[CHANGES];
-      const content = this[CONTENT];
-  
-      return this.Validator.validateSync({ ...normalizeObject(content), ...normalizeObject(changes) }, { abortEarly: false });
-    }
+  async validateSync(): Promise<any> {
+    const changes = this[CHANGES];
+    const content = this[CONTENT];
+
+    return this.Validator.validateSync(
+      { ...normalizeObject(content), ...normalizeObject(changes) },
+      { abortEarly: false }
+    );
+  }
 
   /**
    * Manually add an error to the changeset. If there is an existing

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -195,7 +195,7 @@ export class ValidatedChangeset {
     let obj = this[ERRORS];
     let original = this[CONTENT];
 
-    return newFormat(getKeyValues(obj), original, this.getDeep);
+    return getKeyErrorValues(obj);
   }
 
   get change() {
@@ -395,8 +395,9 @@ export class ValidatedChangeset {
    */
   async validate(): Promise<any> {
     const changes = this[CHANGES];
+    const content = this[CONTENT];
 
-    return this.Validator.validate(normalizeObject(changes));
+    return this.Validator.validate({ ...normalizeObject(content), ...normalizeObject(changes) });
   }
 
   /**
@@ -427,7 +428,7 @@ export class ValidatedChangeset {
     this[ERRORS_CACHE] = this[ERRORS];
 
     // Return passed-in `error`.
-    return error;
+    return newError;
   }
 
   /**

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -28,7 +28,7 @@ import {
   PrepareChangesFn,
   Snapshot,
   ValidationErr,
-  ValidatorKlass,
+  ValidatorKlass
 } from './types';
 
 const { keys } = Object;
@@ -61,11 +61,7 @@ function maybeUnwrapProxy(content: Content): any {
 // This is intended to provide an alternative changeset structure compatible with `yup`
 // This slims down the set of features, including removed APIs and `validate` returns just the `validate()` method call and requires users to manually add errors.
 export class ValidatedChangeset {
-  constructor(
-    obj: object,
-    public Validator: ValidatorKlass,
-    options: Config = {}
-  ) {
+  constructor(obj: object, public Validator: ValidatorKlass, options: Config = {}) {
     this[CONTENT] = obj;
     this[PREVIOUS_CONTENT] = undefined;
     this[CHANGES] = {};

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -193,7 +193,6 @@ export class ValidatedChangeset {
    */
   get errors() {
     let obj = this[ERRORS];
-    let original = this[CONTENT];
 
     return getKeyErrorValues(obj);
   }

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -2409,211 +2409,6 @@ describe('Unit | Utility | validation changeset', () => {
     ]);
   });
 
-  // it('#validate/1 validates a single field immediately', async () => {
-  //   dummyModel.name = 'J';
-  //   dummyModel.password = '123';
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   await dummyChangeset.validate('name');
-  //   expect(get(dummyChangeset, 'error.name')).toEqual({ validation: 'too short', value: 'J' });
-  //   expect(dummyChangeset.changes).toEqual([]);
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(1);
-  // });
-
-  // it('#validate/1 validates with an falsey string value for the validator message', async () => {
-  //   dummyModel.age = 120;
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   await dummyChangeset.validate('age');
-  //   expect(get(dummyChangeset, 'error.age')).toEqual({ validation: '', value: 120 });
-  //   expect(dummyChangeset.changes).toEqual([]);
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(1);
-  // });
-
-  // it('#validate validates a multiple field immediately', async () => {
-  //   dummyModel.name = 'J';
-  //   dummyModel.password = false;
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   await dummyChangeset.validate('name', 'password');
-  //   expect(get(dummyChangeset, 'error.name')).toEqual({ validation: 'too short', value: 'J' });
-  //   expect(get(dummyChangeset, 'error.password')).toEqual({
-  //     validation: ['foo', 'bar'],
-  //     value: false
-  //   });
-  //   expect(dummyChangeset.changes).toEqual([]);
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(2);
-  // });
-
-  // it('#validate/1 validates a property with no validation', async () => {
-  //   dummyModel.org = {};
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   await dummyChangeset.validate('org');
-  //   expect(get(dummyChangeset, 'error.org')).toEqual(undefined);
-  //   expect(dummyChangeset.changes).toEqual([]);
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(0);
-  // });
-
-  // it('#validate works correctly with changeset values', async () => {
-  //   dummyModel = {
-  //     ...dummyModel,
-  //     ...{
-  //       name: undefined,
-  //       email: undefined,
-  //       password: false,
-  //       async: true,
-  //       passwordConfirmation: false,
-  //       options: {},
-  //       org: {
-  //         isCompliant: undefined,
-  //         usa: {
-  //           ny: undefined
-  //         }
-  //       },
-  //       size: {
-  //         value: undefined,
-  //         power10: 10
-  //       }
-  //     }
-  //   };
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(0);
-
-  //   dummyChangeset.set('name', 'Jim Bob');
-
-  //   await dummyChangeset.validate();
-
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(5);
-  //   expect(get(dummyChangeset, 'errors')[0].key).toBe('password');
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-
-  //   dummyChangeset.set('passwordConfirmation', true);
-
-  //   await dummyChangeset.validate();
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(5);
-  //   expect(get(dummyChangeset, 'errors')[0].key).toBe('org.usa.ny');
-  //   expect(get(dummyChangeset, 'errors')[1].key).toBe('org.isCompliant');
-  //   expect(get(dummyChangeset, 'errors')[2].key).toBe('password');
-  //   expect(get(dummyChangeset, 'errors')[3].key).toBe('passwordConfirmation');
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-
-  //   dummyChangeset.set('org.isCompliant', true);
-  //   dummyChangeset.set('password', 'foobar');
-  //   dummyChangeset.set('passwordConfirmation', 'foobar');
-  //   dummyChangeset.set('email', 'scott.mail@gmail.com');
-  //   dummyChangeset.set('org.usa.ny', 'NY');
-  //   dummyChangeset.set('size.value', 1001);
-
-  //   await dummyChangeset.validate();
-
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(0);
-  //   expect(dummyChangeset.isValid).toEqual(true);
-  //   expect((dummyChangeset.size as Record<string, any>).value).toEqual(1001);
-  //   expect((dummyChangeset.size as Record<string, any>).power10).toEqual(10);
-  // });
-
-  // it('#validate works correctly with complex values', () => {
-  //   dummyModel = {};
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   dummyChangeset.set('options', { persist: true });
-  //   dummyChangeset.validate();
-  //   expect(dummyChangeset.changes[0]).toEqual({ key: 'options', value: { persist: true } });
-  // });
-
-  // it('#validate marks actual valid changes', async () => {
-  //   dummyModel = {
-  //     ...dummyModel,
-  //     ...{ name: 'Jim Bob', password: true, passwordConfirmation: true, async: true }
-  //   };
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   dummyChangeset.set('name', 'foo bar');
-  //   dummyChangeset.set('password', false);
-
-  //   await dummyChangeset.validate();
-  //   expect(dummyChangeset.changes).toEqual([
-  //     { key: 'name', value: 'foo bar' },
-  //     { key: 'password', value: false }
-  //   ]);
-  // });
-
-  // it('#validate does not mark changes when nothing has changed', async () => {
-  //   let options = {
-  //     persist: true,
-  //     // test isEqual to ensure we're using Ember.isEqual for comparison
-  //     isEqual(other: Record<string, any>) {
-  //       return this.persist === other.persist;
-  //     }
-  //   };
-  //   dummyModel = {
-  //     ...dummyModel,
-  //     ...{
-  //       name: 'Jim Bob',
-  //       email: 'jimmy@bob.com',
-  //       password: true,
-  //       passwordConfirmation: true,
-  //       async: true,
-  //       options,
-  //       org: {
-  //         isCompliant: true,
-  //         usa: {
-  //           ny: 'NY'
-  //         }
-  //       },
-  //       size: {
-  //         value: 1001,
-  //         power10: 10
-  //       }
-  //     }
-  //   };
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   dummyChangeset.set('options', options);
-
-  //   await dummyChangeset.validate();
-  //   expect(dummyChangeset.error).toEqual({});
-  //   expect(dummyChangeset.changes).toEqual([]);
-  // });
-
-  // it('#validate/nested validates nested fields immediately', async () => {
-  //   dummyModel['org'] = {
-  //     usa: {
-  //       ny: null
-  //     }
-  //   };
-
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-  //   await dummyChangeset.validate('org.usa.ny');
-  //   expect(get(dummyChangeset, 'error.org.usa.ny')).toEqual({
-  //     validation: ['must be present'],
-  //     value: null
-  //   });
-  //   /* expect(dummyChangeset.changes).toEqual([]); */
-  //   /* expect(dummyChangeset.errors.length).toBe(1); */
-  // });
-
-  // it('#validate marks actual valid changes', async () => {
-  //   dummyModel = {
-  //     ...dummyModel,
-  //     ...{ name: 'Jim Bob', password: true, passwordConfirmation: true }
-  //   };
-  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
-
-  //   dummyChangeset.set('name', 'foo bar');
-  //   dummyChangeset.set('password', false);
-  //   dummyChangeset.set('async', true);
-
-  //   await dummyChangeset.validate();
-  //   expect(dummyChangeset.changes).toEqual([
-  //     { key: 'name', value: 'foo bar' },
-  //     { key: 'password', value: false },
-  //     { key: 'async', value: true }
-  //   ]);
-  // });
-
   /**
    * #addError
    */
@@ -2636,110 +2431,75 @@ describe('Unit | Utility | validation changeset', () => {
     expect(dummyChangeset.isValid).toEqual(true);
   });
 
-  // it('#addError adds an error then validates', async () => {
-  //   let dummyChangeset = Changeset(dummyModel);
-  //   dummyChangeset.addError('email', {
-  //     value: 'jim@bob.com',
-  //     validation: 'Email already taken'
-  //   });
+  it('#addError adds an error to the changeset on a nested property', () => {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.addError('email.localPart', 'Cannot contain +');
 
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-  //   await dummyChangeset.validate();
+    expect(dummyChangeset.isInvalid).toEqual(true);
+    expect(get(dummyChangeset, 'error.email.localPart.validation')).toBe('Cannot contain +');
+    dummyChangeset.set('email.localPart', 'ok');
+  });
 
-  //   expect(get(dummyChangeset, 'error.email')).toEqual({
-  //     validation: 'Email already taken',
-  //     value: 'jim@bob.com'
-  //   });
-  //   expect(dummyChangeset.changes).toEqual([]);
-  //   expect(get(dummyChangeset, 'errors.length')).toBe(1);
-  // });
+  it('#addError adds an array of errors to the changeset', () => {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.addError('email', ['jim@bob.com', 'Email already taken']);
 
-  // it('#addError adds an error to the changeset using the shortcut', function() {
-  //   let dummyChangeset = Changeset(dummyModel);
-  //   dummyChangeset.set('email', 'jim@bob.com');
-  //   dummyChangeset.addError('email', 'Email already taken');
+    expect(dummyChangeset.isInvalid).toEqual(true);
+    expect(get(dummyChangeset, 'error.email.validation')).toEqual([
+      'jim@bob.com',
+      'Email already taken'
+    ]);
+    dummyChangeset.set('email', 'unique@email.com');
+  });
 
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-  //   expect(get(dummyChangeset, 'error.email.validation')).toBe('Email already taken');
-  //   expect(get(dummyChangeset, 'error.email.value')).toBe('jim@bob.com');
-  //   expect(dummyChangeset.changes).toEqual([{ key: 'email', value: 'jim@bob.com' }]);
-  //   dummyChangeset.set('email', 'unique@email.com');
-  //   expect(dummyChangeset.isValid).toEqual(true);
-  //   expect(dummyChangeset.changes[0]).toEqual({ key: 'email', value: 'unique@email.com' });
-  // });
+  /**
+   * #pushErrors
+   */
 
-  // it('#addError adds an error to the changeset on a nested property', () => {
-  //   let dummyChangeset = Changeset(dummyModel);
-  //   dummyChangeset.addError('email.localPart', 'Cannot contain +');
+  it('#pushErrors pushes an error into an array of existing validations', function() {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.set('email', 'jim@bob.com');
+    dummyChangeset.addError('email', 'Email already taken');
+    dummyChangeset.pushErrors('email', 'Invalid email format');
 
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-  //   expect(get(dummyChangeset, 'error.email.localPart.validation')).toBe('Cannot contain +');
-  //   dummyChangeset.set('email.localPart', 'ok');
-  //   expect(dummyChangeset.isValid).toEqual(true);
-  // });
+    expect(dummyChangeset.isInvalid).toEqual(true);
+    expect(get(dummyChangeset, 'error.email.validation')).toEqual([
+      'Email already taken',
+      'Invalid email format'
+    ]);
+    expect(get(dummyChangeset, 'error.email.value')).toBe('jim@bob.com');
+    expect(dummyChangeset.changes).toEqual({ email: { current: 'jim@bob.com', original: undefined } });
+    dummyChangeset.set('email', 'unique@email.com');
+    expect(dummyChangeset.changes).toEqual({ email: { current: 'unique@email.com', original: undefined } });
+  });
 
-  // it('#addError adds an array of errors to the changeset', () => {
-  //   let dummyChangeset = Changeset(dummyModel);
-  //   dummyChangeset.addError('email', ['jim@bob.com', 'Email already taken']);
+  it('#pushErrors pushes an error if no existing validations are present', async function() {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.set('name', 'J');
+    dummyChangeset.pushErrors('name', 'cannot be J');
 
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-  //   expect(get(dummyChangeset, 'error.email.validation')).toEqual([
-  //     'jim@bob.com',
-  //     'Email already taken'
-  //   ]);
-  //   dummyChangeset.set('email', 'unique@email.com');
-  //   expect(dummyChangeset.isValid).toEqual(true);
-  // });
+    expect(dummyChangeset.isInvalid).toEqual(true);
+    try {
+      await dummyChangeset.validate(changes => userSchema.validate(changes));
+    } catch (e) {
+      dummyChangeset.addError(e.path, { value: e.value.age, validation: e.message });
+    }
+    expect(get(dummyChangeset, 'error.name.validation')).toEqual(['cannot be J']);
+    expect(get(dummyChangeset, 'error.name.value')).toBe('J');
+    expect(dummyChangeset.isInvalid).toEqual(true);
+  });
 
-  // /**
-  //  * #pushErrors
-  //  */
+  it('#pushErrors adds an error to the changeset on a nested property', () => {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.pushErrors('email.localPart', 'Cannot contain +');
+    dummyChangeset.pushErrors('email.localPart', 'is too short');
 
-  // it('#pushErrors pushes an error into an array of existing validations', function() {
-  //   let dummyChangeset = Changeset(dummyModel);
-  //   dummyChangeset.set('email', 'jim@bob.com');
-  //   dummyChangeset.addError('email', 'Email already taken');
-  //   dummyChangeset.pushErrors('email', 'Invalid email format');
-
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-  //   expect(get(dummyChangeset, 'error.email.validation')).toEqual([
-  //     'Email already taken',
-  //     'Invalid email format'
-  //   ]);
-  //   expect(get(dummyChangeset, 'error.email.value')).toBe('jim@bob.com');
-  //   expect(dummyChangeset.changes).toEqual([{ key: 'email', value: 'jim@bob.com' }]);
-  //   dummyChangeset.set('email', 'unique@email.com');
-  //   expect(dummyChangeset.isValid).toEqual(true);
-  //   expect(dummyChangeset.changes[0]).toEqual({ key: 'email', value: 'unique@email.com' });
-  // });
-
-  // it('#pushErrors pushes an error if no existing validations are present', function() {
-  //   let dummyChangeset = Changeset(dummyModel));
-  //   dummyChangeset.set('name', 'J');
-  //   dummyChangeset.pushErrors('name', 'cannot be J');
-
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-  //   expect(dummyChangeset.isValid).toEqual(false);
-  //   expect(get(dummyChangeset, 'error.name.validation')).toEqual(['too short', 'cannot be J']);
-  //   expect(get(dummyChangeset, 'error.name.value')).toBe('J');
-  //   dummyChangeset.set('name', 'Good name');
-  //   expect(dummyChangeset.isValid).toEqual(true);
-  //   expect(dummyChangeset.isInvalid).toEqual(false);
-  // });
-
-  // it('#pushErrors adds an error to the changeset on a nested property', () => {
-  //   let dummyChangeset = Changeset(dummyModel);
-  //   dummyChangeset.pushErrors('email.localPart', 'Cannot contain +');
-  //   dummyChangeset.pushErrors('email.localPart', 'is too short');
-
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-  //   expect(get(dummyChangeset, 'error.email.localPart.validation')).toEqual([
-  //     'Cannot contain +',
-  //     'is too short'
-  //   ]);
-  //   dummyChangeset.set('email.localPart', 'ok');
-  //   expect(dummyChangeset.isValid).toEqual(true);
-  // });
+    expect(get(dummyChangeset, 'error.email.localPart.validation')).toEqual([
+      'Cannot contain +',
+      'is too short'
+    ]);
+    dummyChangeset.set('email.localPart', 'ok');
+  });
 
   /**
    * #snapshot

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -1,0 +1,3256 @@
+import { ValidationChangeset as Changeset } from '../src';
+import get from '../src/utils/get-deep';
+import set from '../src/utils/set-deep';
+import { array, object, string, number, date, InferType } from 'yup';
+
+let userSchema = object({
+  name: string().required(),
+  age: number().required().positive().integer(),
+  email: string().email(),
+  teams: array(string()),
+  website: string().url().nullable(),
+  createdOn: date().default(() => new Date()),
+});
+
+let dogSchema = object({
+  name: string().required(),
+  age: number().required().positive().integer(),
+});
+
+let dummyModel: any = {};
+const exampleArray: Array<any> = [];
+
+describe('Unit | Utility | validation changeset', () => {
+  beforeEach(() => {
+    dummyModel = {};
+  });
+  /**
+   * #toString
+   */
+
+  it('content can be an empty hash', () => {
+    expect.assertions(1);
+
+    const emptyObject = {};
+    const dummyChangeset = Changeset(emptyObject, userSchema);
+
+    expect(dummyChangeset.toString()).toEqual('changeset:[object Object]');
+  });
+
+  /**
+   * #change
+   */
+
+  it('#change returns the changes object', () => {
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const expectedResult = { name: 'a' };
+    dummyChangeset.set('name', 'a');
+
+    expect(dummyChangeset.change).toEqual(expectedResult);
+  });
+
+  it('#change supports `undefined`', () => {
+    const model = { name: 'a' };
+    const dummyChangeset = Changeset(model, userSchema);
+    const expectedResult = { name: undefined };
+    dummyChangeset.set('name', undefined);
+
+    expect(dummyChangeset.change).toEqual(expectedResult);
+  });
+
+  it('#change works with arrays', () => {
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const newArray = [...exampleArray, 'new'];
+    const expectedResult = { teams: newArray };
+    dummyChangeset.set('teams', newArray);
+
+    expect(dummyChangeset.change).toEqual(expectedResult);
+  });
+
+  // /**
+  //  * #errors
+  //  */
+  // it('#errors returns the error object and keeps changes', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let expectedResult = [{ key: 'name', validation: 'too short', value: 'a' }];
+  //   dummyChangeset.set('name', 'a');
+
+  //   expect(dummyChangeset.errors).toEqual(expectedResult);
+  //   expect(dummyChangeset.get('errors')).toEqual(expectedResult);
+  // });
+
+  // it('can get nested values in the errors object', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('unknown', 'wat');
+  //   dummyChangeset.set('org.usa.ny', '');
+  //   dummyChangeset.set('name', '');
+
+  //   let expectedErrors = [
+  //     { key: 'org.usa.ny', validation: ['must be present', 'only letters work'], value: '' },
+  //     { key: 'name', validation: 'too short', value: '' }
+  //   ];
+  //   expect(dummyChangeset.get('errors')).toEqual(expectedErrors);
+
+  //   dummyChangeset.set('org.usa.ny', '1');
+  //   expectedErrors = [
+  //     { key: 'org.usa.ny', validation: ['only letters work'], value: '1' },
+  //     { key: 'name', validation: 'too short', value: '' }
+  //   ];
+  //   expect(dummyChangeset.get('errors')).toEqual(expectedErrors);
+  // });
+
+  // /**
+  //  * #changes
+  //  */
+
+  /**
+   * #data
+   */
+
+  it('data reads the changeset CONTENT', () => {
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+
+    expect(dummyChangeset.data).toEqual(dummyModel);
+  });
+
+  /**
+   * #isValid
+   */
+  it('does not validate with default options', () => {
+    const dummyChangeset = Changeset(
+      dummyModel,
+      userSchema
+    );
+
+    expect(dummyChangeset.get('isValid')).toBeTruthy();
+  });
+
+  // /**
+  //  * #isInvalid
+  //  */
+
+  /**
+   * #isPristine
+   */
+
+  it("isPristine returns true if changes are equal to content's values", () => {
+    dummyModel.name = 'Bobby';
+    dummyModel.thing = 123;
+    dummyModel.nothing = null;
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', 'Bobby');
+    dummyChangeset.set('nothing', null);
+
+    expect(dummyChangeset.get('isPristine')).toBeTruthy();
+  });
+
+  it("isPristine returns false if changes are not equal to content's values", () => {
+    dummyModel.name = 'Bobby';
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', 'Bobby');
+    dummyChangeset.set('thing', 123);
+
+    expect(dummyChangeset.get('isPristine')).toBeFalsy();
+  });
+
+  it('isPristine works with `null` values', () => {
+    dummyModel.name = null;
+    dummyModel.age = 15;
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+
+    expect(dummyChangeset.get('isPristine')).toBeTruthy();
+
+    dummyChangeset.set('name', 'Kenny');
+    expect(dummyChangeset.get('isPristine')).toBeFalsy();
+
+    dummyChangeset.set('name', null);
+    expect(dummyChangeset.get('isPristine')).toBeTruthy();
+  });
+
+  /**
+   * #isDirty
+   */
+
+  it('#set dirties changeset', () => {
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', 'foo');
+
+    expect(dummyChangeset.isDirty).toBe(true);
+  });
+
+  it('#isDirty after set', () => {
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', 'foo');
+
+    expect(dummyChangeset.isDirty).toBe(true);
+  });
+
+  it('#isDirty reset after execute', () => {
+    dummyModel.name = {};
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = {
+      short: 'foo'
+    };
+
+    expect(dummyChangeset.get('isDirty')).toBe(true);
+
+    dummyChangeset.execute();
+
+    expect(dummyChangeset.get('isDirty')).toBe(false);
+  });
+
+  it('#isDirty reset after rollback', () => {
+    dummyModel.name = {};
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = {
+      short: 'foo'
+    };
+
+    expect(dummyChangeset.get('isDirty')).toBe(true);
+
+    dummyChangeset.rollback();
+
+    expect(dummyChangeset.get('isDirty')).toBe(false);
+  });
+
+  it('#isDirty is false when no set', () => {
+    dummyModel['name'] = { nick: 'bar' };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.name;
+
+    expect(dummyChangeset.isDirty).toBe(false);
+  });
+
+  it('#isDirty is false when no set with deep values', () => {
+    dummyModel['details'] = { name: { nick: 'bar' } };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.get('details.name');
+
+    expect(dummyChangeset.isDirty).toBe(false);
+    expect(dummyChangeset.change).toEqual({});
+  });
+
+  it('#isDirty is true when set with deep values', () => {
+    class Dog {
+      value: any;
+      constructor(value: any) {
+        this.value = value;
+      }
+    }
+    dummyModel['details'] = { name: {} };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.get('details.name');
+    const dogKlass = new Dog({ nickname: 'bar' });
+    dummyChangeset['details'] = { name: dogKlass };
+
+    expect(dummyChangeset.isDirty).toBe(true);
+    expect(dummyChangeset.change).toEqual({ details: { name: dogKlass } });
+  });
+
+  it('#set does not dirty changeset with same date', () => {
+    dummyModel.createTime = new Date('2013-05-01');
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('createTime', new Date('2013-05-01'));
+
+    expect(dummyChangeset.isDirty).toBe(false);
+  });
+
+  /**
+   * #get
+   */
+
+  it('#get proxies to content', () => {
+    dummyModel.name = 'Jim Bob';
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const result = dummyChangeset.name;
+
+    expect(result).toBe('Jim Bob');
+  });
+
+  it('#get proxies to content prototype', () => {
+    class Dog {
+      name?: string;
+    }
+    Dog.prototype.name = 'Jim Bob';
+    const dummyChangeset = Changeset(new Dog(), userSchema);
+    const result = dummyChangeset.name;
+
+    expect(result).toBe('Jim Bob');
+  });
+
+  it('#get returns the content when the proxied content is a class', () => {
+    class Moment {
+      date: unknown;
+      constructor(date: Date) {
+        this.date = date;
+      }
+    }
+
+    const d = new Date('2015');
+    const momentInstance = new Moment(d);
+    const c = Changeset({
+      startDate: momentInstance
+    }, userSchema);
+
+    const newValue = c.get('startDate');
+    expect(newValue.date).toEqual(momentInstance.date);
+    expect(newValue.content instanceof Moment).toBeTruthy();
+    expect(newValue.date).toBe(d);
+  });
+
+  it('#get handles changes that are non primitives', () => {
+    class Moment {
+      _isUTC: any;
+      date: unknown;
+      constructor(date: Date) {
+        this.date = date;
+        this._isUTC = false;
+      }
+    }
+
+    const d = new Date('2015');
+    const momentInstance = new Moment(d);
+    momentInstance._isUTC = true;
+    const c = Changeset({
+      startDate: momentInstance
+    }, userSchema);
+
+    let newValue = c.get('startDate');
+    expect(newValue.date).toEqual(momentInstance.date);
+    expect(newValue.content instanceof Moment).toBeTruthy();
+    expect(newValue.date).toBe(d);
+    expect(newValue._isUTC).toEqual(true);
+
+    const newD = new Date('2020');
+    const newMomentInstance = new Moment(newD);
+    c.set('startDate', newMomentInstance);
+
+    newValue = c.get('startDate');
+    newMomentInstance._isUTC = undefined;
+    expect(newValue).toEqual(newMomentInstance);
+    expect(newValue instanceof Moment).toBeTruthy();
+    expect(newValue.date).toBe(newD);
+    expect(newValue._isUTC).toBeUndefined();
+  });
+
+  it('#get merges sibling keys from CONTENT with CHANGES', () => {
+    class Moment {
+      _isUTC: boolean;
+      date: unknown;
+      constructor(date: Date) {
+        this.date = date;
+        this._isUTC = false;
+      }
+    }
+
+    const d = new Date('2015');
+    const momentInstance = new Moment(d);
+    momentInstance._isUTC = true;
+    const c = Changeset({
+      startDate: momentInstance
+    }, userSchema);
+
+    let newValue = c.get('startDate');
+    expect(newValue.date).toEqual(momentInstance.date);
+    expect(newValue.content instanceof Moment).toBeTruthy();
+    expect(newValue.date).toBe(d);
+    expect(newValue._isUTC).toEqual(true);
+
+    const newD = new Date('2020');
+    c.set('startDate.date', newD);
+
+    newValue = c.get('startDate');
+    expect(newValue.date).toEqual(newD);
+    expect(newValue.content instanceof Moment).toBeTruthy();
+    expect(newValue.date).toBe(newD);
+    expect(newValue._isUTC).toBe(true);
+  });
+
+  it('#get returns change if present', () => {
+    dummyModel.name = 'Jim Bob';
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = 'Milton Waddams';
+    const result = dummyChangeset.name;
+
+    expect(result).toBe('Milton Waddams');
+  });
+
+  it('#get returns change that is a blank value', () => {
+    dummyModel.name = 'Jim Bob';
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = '';
+    const result = dummyChangeset.name;
+
+    expect(result).toBe('');
+  });
+
+  it('#get returns change that is has undefined as value', () => {
+    dummyModel.name = 'Jim Bob';
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = undefined;
+    const result = dummyChangeset.name;
+
+    expect(result).toBeUndefined();
+  });
+
+  it('#get nested objects can contain arrays', () => {
+    expect.assertions(7);
+    dummyModel.name = 'Bob';
+    dummyModel.contact = {
+      emails: ['bob@email.com', 'the_bob@email.com']
+    };
+
+    expect(get(dummyModel, 'contact.emails')).toEqual(['bob@email.com', 'the_bob@email.com']);
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    expect(dummyChangeset.get('name')).toBe('Bob');
+    expect(dummyChangeset.get('contact.emails')).toEqual(['bob@email.com', 'the_bob@email.com']);
+
+    dummyChangeset.set('contact.emails', ['fred@email.com', 'the_fred@email.com']);
+
+    expect(dummyChangeset.get('contact.emails')).toEqual(['fred@email.com', 'the_fred@email.com']);
+
+    dummyChangeset.rollback();
+    expect(dummyChangeset.get('contact.emails')).toEqual(['bob@email.com', 'the_bob@email.com']);
+    dummyChangeset.set('contact.emails', ['fred@email.com', 'the_fred@email.com']);
+    expect(dummyChangeset.get('contact.emails')).toEqual(['fred@email.com', 'the_fred@email.com']);
+
+    dummyChangeset.execute();
+    expect(dummyModel.contact.emails).toEqual(['fred@email.com', 'the_fred@email.com']);
+  });
+
+  it('#getted Object proxies to underlying method', () => {
+    class Dog {
+      breed: string;
+      constructor(b: string) {
+        this.breed = b;
+      }
+
+      bark() {
+        return `woof i'm a ${this.breed}`;
+      }
+    }
+
+    const model: Record<string, any> = {
+      foo: {
+        bar: {
+          dog: new Dog('shiba inu, wow')
+        }
+      }
+    };
+
+    {
+      const c = Changeset(model, dogSchema);
+      const actual = c.get('foo.bar.dog');
+      const expectedResult = "woof i'm a shiba inu, wow";
+      expect(actual.bark()).toEqual(expectedResult);
+    }
+
+    {
+      const c = Changeset(model, dogSchema);
+      const actual = get(c, 'foo.bar.dog');
+      const expectedResult = get(model, 'foo.bar.dog');
+      expect(actual).toEqual(expectedResult);
+    }
+
+    {
+      const c = Changeset(model, dogSchema);
+      const actual = get(c, 'foo.bar.dog');
+      const expectedResult = get(model, 'foo.bar.dog');
+      expect(actual).toEqual(expectedResult);
+    }
+  });
+
+  it('#get proxies to underlying array properties', () => {
+    dummyModel.users = ['user1', 'user2'];
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+
+    expect((dummyChangeset.users as Array<string>).length).toBe(2);
+  });
+
+  it('#get works if content is undefined for nested key', () => {
+    const model: Record<string, any> = {};
+
+    const c = Changeset(model, dogSchema);
+    c.set('foo.bar.cat', {
+      color: 'red'
+    });
+    const cat = c.get('foo.bar.cat');
+    expect(cat.color).toEqual('red');
+  });
+
+  it('#get works with toString override', () => {
+    dummyModel.toString = function() {
+      return 'mine';
+    };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = undefined;
+    const result = dummyChangeset.toString();
+
+    expect(result).toEqual('changeset:mine');
+  });
+
+  it('#get prioritizes own methods/getters', () => {
+    dummyModel.trigger = function(arg: any) {
+      expect(arg).toEqual('mine');
+    };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = undefined;
+    dummyChangeset.trigger('mine');
+  });
+
+  /**
+   * #set
+   */
+
+  it('#set adds a change if valid', () => {
+    const expectedChanges = { name: { current: 'foo', original: undefined } };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', 'foo');
+    const changes = dummyChangeset.changes;
+
+    expect(dummyModel.name).toBeUndefined();
+    expect(dummyChangeset.get('name')).toEqual('foo');
+
+    expect(changes).toEqual(expectedChanges);
+    expect(dummyChangeset.isDirty).toBe(true);
+    expect(dummyChangeset.change).toEqual({ name: 'foo' });
+  });
+
+  it('#set adds a change with plain assignment without existing values', () => {
+    dummyModel['name'] = { nick: 'bar' };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const proxy: any = dummyChangeset.name;
+    proxy['nick'] = 'foo';
+    expect(dummyChangeset.get('name.nick')).toEqual('foo');
+
+    const expectedChanges = { 'name.nick': { current: 'foo', original: 'bar' } };
+    const changes = dummyChangeset.changes;
+    expect(changes).toEqual(expectedChanges);
+  });
+
+  it('#set adds a change with plain assignment', () => {
+    dummyModel['name'] = 'bar';
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = 'foo';
+    const changes = dummyChangeset.changes;
+
+    expect(dummyModel.name).toBe('bar');
+    expect(dummyChangeset.name).toEqual('foo');
+
+    const expectedChanges = { name: { current: 'foo', original: 'bar' } };
+    expect(changes).toEqual(expectedChanges);
+  });
+
+  it('#set adds a date', () => {
+    const d = new Date();
+    const expectedChanges = { dateOfBirth: { current: d, original: undefined } };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('dateOfBirth', d);
+    const changes = dummyChangeset.changes;
+
+    expect(dummyModel.dateOfBirth).toBeUndefined();
+    expect(dummyChangeset.get('dateOfBirth')).toEqual(d);
+
+    expect(changes).toEqual(expectedChanges);
+  });
+
+  it('#set adds a date if already set on model', () => {
+    const model = { dateOfBirth: new Date() };
+    const dummyChangeset = Changeset(model, userSchema);
+    const d = new Date('March 25, 1990');
+    dummyChangeset.set('dateOfBirth', d);
+    const changes = dummyChangeset.changes;
+
+    expect(dummyModel.dateOfBirth).toBeUndefined();
+    expect(dummyChangeset.get('dateOfBirth')).toEqual(d);
+    expect(dummyChangeset.dateOfBirth).toEqual(d);
+
+    const expectedChanges = { dateOfBirth: { current: d, original: model.dateOfBirth } };
+    expect(changes).toEqual(expectedChanges);
+  });
+
+  it('#set Ember.set works', () => {
+    const expectedChanges = { name: { current: 'foo', original: undefined } };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = 'foo';
+
+    expect(dummyModel.name).toBeUndefined();
+    expect(dummyChangeset.get('name')).toBe('foo');
+
+    const changes = dummyChangeset.changes;
+    expect(changes).toEqual(expectedChanges);
+
+    dummyChangeset.execute();
+
+    expect(dummyModel.name).toBe('foo');
+    expect(dummyChangeset.get('name')).toBe('foo');
+  });
+
+  it('#set works for nested', () => {
+    const expectedChanges = { name: { current: { short: 'foo' }, original: {} } };
+    dummyModel.name = {};
+    dummyModel.org = {};
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset['name'] = {
+      short: 'foo'
+    };
+
+    expect(dummyChangeset.get('name.short')).toBe('foo');
+    expect(dummyModel.name).toEqual({});
+
+    const changes = dummyChangeset.changes;
+    expect(changes).toEqual(expectedChanges);
+    expect(dummyChangeset.name).toEqual({ short: 'foo' });
+    expect(dummyChangeset.org).toEqual({});
+
+    dummyChangeset.execute();
+
+    expect(dummyModel.name.short).toBe('foo');
+  });
+
+  it('#set overrides', () => {
+    const expectedChanges = { age: { current: '90', original: '10' } };
+    let dummyChangeset = Changeset({ age: '10' }, userSchema);
+    dummyChangeset.set('age', '80');
+    dummyChangeset.set('age', '10');
+    dummyChangeset.set('age', '90');
+
+    const changes = dummyChangeset.changes;
+
+    expect(dummyModel.age).toBeUndefined();
+    expect(dummyChangeset.get('age')).toEqual('90');
+
+    expect(changes).toEqual(expectedChanges);
+    expect(dummyChangeset.isDirty).toBe(true);
+    expect(dummyChangeset.change).toEqual({ age: '90' });
+  });
+
+  test('#set Ember.set with Object actually does work TWICE for nested', () => {
+    set(dummyModel, 'name', {});
+    let title1 = { id: 'Mr', description: 'Mister' };
+    let title2 = { id: 'Mrs', description: 'Missus' };
+    let dummyChangeset: any = Changeset(dummyModel, userSchema);
+    set(dummyChangeset, 'name.title', title1);
+
+    expect(get(dummyModel, 'name.title.id')).toBeUndefined();
+    expect(dummyChangeset.name.title.id).toEqual('Mr');
+    expect(dummyChangeset.get('name.title.id')).toEqual('Mr');
+
+    let changes = get(dummyChangeset, 'changes');
+    let expected = {'name.title': {current: title1, original: undefined}};
+    expect(changes).toEqual(expected);
+
+    set(dummyChangeset, 'name.title', title2);
+
+    expect(get(dummyModel, 'name.title.id')).toBeUndefined();
+    expect(dummyChangeset.name.title.id).toEqual('Mrs');
+    expect(dummyChangeset.get('name.title.id')).toEqual('Mrs');
+
+    changes = get(dummyChangeset, 'changes');
+    expected = {'name.title': {current: title2, original: undefined}};
+    expect(changes).toEqual(expected);
+
+    dummyChangeset.execute();
+
+    expect(dummyModel.name.title.id).toEqual('Mrs');
+  });
+
+  test('#set with Object should work TWICE for nested', () => {
+    set(dummyModel, 'name', {});
+    let title1 = { id: 'Mr', description: 'Mister' };
+    let title2 = { id: 'Mrs', description: 'Missus' };
+    let dummyChangeset: any = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name.title', title1);
+
+    expect(get(dummyModel, 'name.title.id')).toBeUndefined();
+    expect(dummyChangeset.name.title.id).toEqual('Mr');
+    expect(dummyChangeset.get('name.title.id')).toEqual('Mr');
+
+    let changes = dummyChangeset.changes;
+    let expected = {'name.title': {current: title1, original: undefined}};
+    expect(changes).toEqual(expected);
+
+    dummyChangeset.set('name.title', title2);
+
+    expect(get(dummyModel, 'name.title.id')).toBeUndefined();
+    expect(dummyChangeset.name.title.id).toEqual('Mrs');
+    expect(dummyChangeset.get('name.title.id')).toEqual('Mrs');
+
+    changes = dummyChangeset.changes;
+    expected = {'name.title': {current: title2, original: undefined}};
+    expect(changes).toEqual(expected);
+
+    dummyChangeset.execute();
+
+    expect(dummyModel.name.title.id).toEqual('Mrs');
+  });
+
+  describe('arrays within nested objects', () => {
+    describe('#set', () => {
+      let initialData: { contact: { emails?: string[] } } = { contact: { emails: [] } };
+
+      beforeEach(() => {
+        initialData = { contact: { emails: ['bob@email.com'] } };
+      });
+
+      it('works with boolean values', () => {
+        let initialData = { contact: { emails: [{}, {}] } };
+
+        const changeset = Changeset(initialData, userSchema);
+
+        changeset.set('contact.emails.2', { nested: false });
+        expect(changeset.get('contact.emails.2')).toEqual({ nested: false });
+
+        changeset.set('contact.emails.2.nested', true);
+        expect(changeset.get('contact.emails.2')).toEqual({ nested: true });
+
+        changeset.set('contact.emails.2.nested', false);
+        expect(changeset.get('contact.emails.2')).toEqual({ nested: false });
+      });
+
+      it('nested objects cannot create arrays when we have no hints', () => {
+        initialData.contact = {};
+
+        const changeset = Changeset(initialData, userSchema);
+        expect(changeset.get('contact.emails')).toEqual(undefined);
+
+        changeset.set('contact.emails.0', 'fred@email.com');
+        expect(changeset.get('contact.emails.0')).toEqual('fred@email.com');
+        expect(changeset.get('contact.emails')).toEqual({ '0': 'fred@email.com' });
+      });
+
+      it('can be rolled back', () => {
+        const changeset = Changeset(initialData, userSchema);
+
+        changeset.set('contact.emails.0', 'fred@email.com');
+
+        expect(changeset.get('contact.emails.0')).toEqual('fred@email.com');
+        const expected =  {'contact.emails.0': {current: 'fred@email.com', original: 'bob@email.com'} };
+        expect(changeset.changes).toEqual(expected);
+        expect(changeset.get('contact.emails').unwrap()).toEqual(['fred@email.com']);
+
+        changeset.rollback();
+
+        expect(changeset.get('contact.emails.0')).toEqual('bob@email.com');
+        expect(changeset.changes).toEqual({});
+        expect(changeset.get('contact.emails')).toEqual(['bob@email.com']);
+      });
+
+      it('can add items to the array', () => {
+        const changeset = Changeset(initialData, userSchema);
+
+        changeset.set('contact.emails.1', 'fred@email.com');
+
+        expect(changeset.get('contact.emails.1')).toEqual('fred@email.com');
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          'bob@email.com',
+          'fred@email.com'
+        ]);
+        let expected: any = { 'contact.emails.1': {current: 'fred@email.com', 'original': undefined } }
+        expect(changeset.changes).toEqual(expected);
+
+        changeset.set('contact.emails.3', 'greg@email.com');
+
+        expect(changeset.get('contact.emails.3')).toEqual('greg@email.com');
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          'bob@email.com',
+          'fred@email.com',
+          undefined,
+          'greg@email.com'
+        ]);
+        expected = { 'contact.emails.1': { current: 'fred@email.com', original: undefined }, 'contact.emails.3': { current: 'greg@email.com', original: undefined } };
+        expect(changeset.changes).toEqual(expected);
+
+        expect(changeset.change).toEqual({
+          contact: { emails: { 1: 'fred@email.com', 3: 'greg@email.com' } }
+        });
+      });
+
+      it('can remove items from the array', () => {
+        const changeset = Changeset(initialData, userSchema);
+
+        changeset.set('contact.emails.1', 'fred@email.com');
+
+        expect(changeset.get('contact.emails.1')).toEqual('fred@email.com');
+        expect(changeset.get('contact.emails').unwrap()).toEqual([
+          'bob@email.com',
+          'fred@email.com'
+        ]);
+        let expected: any = { 'contact.emails.1': {current: 'fred@email.com', 'original': undefined } }
+        expect(changeset.changes).toEqual(expected);
+
+        changeset.set('contact.emails.0', null);
+
+        expect(changeset.get('contact.emails.0')).toEqual(null);
+        expect(changeset.get('contact.emails').unwrap()).toEqual([null, 'fred@email.com']);
+        expected = { 'contact.emails.0': { current: null, original: 'bob@email.com' }, 'contact.emails.1': { current: 'fred@email.com', original: undefined } };
+        expect(changeset.changes).toEqual(expected);
+
+        changeset.set('contact.emails.1', null);
+
+        expected = { 'contact.emails.0': { current: null, original: 'bob@email.com' }, 'contact.emails.1': { current: null, original: undefined } };
+        expect(changeset.get('contact.emails').unwrap()).toEqual([null, null]);
+        expect(changeset.changes).toEqual(expected);
+      });
+
+      it('can add an item to an index in an array where that item was previously removed', () => {
+        const deepObj = (email: string) => ({
+          emails: {
+            primary: email
+          }
+        });
+        const bob = deepObj('bob@email.com');
+        const fred = deepObj('fred@email.com');
+        const sanHolo = deepObj('sanholo@email.com');
+
+        const changeset = Changeset({
+          contacts: [bob, fred]
+        }, userSchema);
+
+        // "Delete" array element
+        changeset.set('contacts.0', null);
+
+        expect(changeset.isDirty).toBeTruthy();
+        expect(changeset.get('contacts.0')).toEqual(null);
+        expect(changeset.get('contacts')).toEqual([null, fred]);
+        let expected: any = {'contacts.0': { current: null, original: bob } };
+        expect(changeset.changes).toEqual(expected);
+
+        // Set array element to entirely new object
+        changeset.set('contacts.0', sanHolo);
+
+        expect(changeset.isDirty).toBeTruthy();
+        expect(changeset.get('contacts')).toEqual([sanHolo, fred]);
+        expect(changeset.get('contacts.0.emails.primary')).toEqual('sanholo@email.com');
+        expected = {'contacts.0': { current: sanHolo, original: sanHolo } }; // todo: is 'original' sanHolo concerning?
+        expect(changeset.changes).toEqual(expected);
+
+        // "Delete" array element again
+        changeset.set('contacts.0', null);
+
+        expect(changeset.isDirty).toBeTruthy();
+        expect(changeset.get('contacts.0')).toEqual(null);
+        expect(changeset.get('contacts')).toEqual([null, fred]);
+        expected = {'contacts.0': { current: null, original: sanHolo } };
+        expect(changeset.changes).toEqual(expected);
+
+        // Revert everything
+        changeset.rollback();
+        expect(changeset.isDirty).toBeFalsy();
+        expect(changeset.changes).toEqual({});
+        expect(changeset.get('contacts')).toEqual([bob, fred]);
+      });
+
+      xit(`negative values are not allowed`, () => {
+        // This test is currently disabled because setDeep doesn't have a reference to the
+        // original array and setDeep is where we'd throw on invalid key values
+        const changeset = Changeset(initialData, userSchema);
+
+        expect(changeset.get('contact.emails')).toEqual(['bob@email.com']);
+
+        expect(() => {
+          changeset.set('contact.emails.-1', 'fred@email.com');
+        }).toThrow(
+          'Negative indices are not allowed as arrays do not serialize values at negative indices'
+        );
+      });
+    });
+  });
+
+  // describe('arrays as values of top level objects', () => {
+  //   let initialData: { emails: Record<string, string>[] } = { emails: [] };
+
+  //   beforeEach(() => {
+  //     initialData = { emails: [{ primary: 'bob@email.com' }] };
+  //   });
+
+  //   it('can modify properties on an entry', () => {
+  //     const changeset = Changeset(initialData, userSchema);
+
+  //     changeset.set('emails.0.primary', 'fun@email.com');
+
+  //     expect(changeset.get('emails.0.primary')).toEqual('fun@email.com');
+  //     expect(changeset.get('emails')).toEqual([{ primary: 'fun@email.com' }]);
+  //     expect(changeset.changes).toEqual([{ key: 'emails.0.primary', value: 'fun@email.com' }]);
+  //   });
+
+  //   it('can add properties to an entry', () => {
+  //     const changeset = Changeset(initialData, userSchema);
+
+  //     changeset.set('emails.0.funEmail', 'fun@email.com');
+
+  //     expect(changeset.get('emails.0.funEmail')).toEqual('fun@email.com');
+  //     expect(changeset.changes).toEqual([{ key: 'emails.0.funEmail', value: 'fun@email.com' }]);
+  //     expect(changeset.get('emails')).toEqual([
+  //       { primary: 'bob@email.com', funEmail: 'fun@email.com' }
+  //     ]);
+  //   });
+
+  //   it('can add new properties to new entries', () => {
+  //     const changeset = Changeset(initialData, userSchema);
+
+  //     changeset.set('emails.1.funEmail', 'fun@email.com');
+  //     changeset.set('emails.1.primary', 'primary@email.com');
+
+  //     expect(changeset.get('emails.1.funEmail')).toEqual('fun@email.com');
+  //     expect(changeset.get('emails.1.primary')).toEqual('primary@email.com');
+  //     expect(changeset.get('emails')).toEqual([
+  //       { primary: 'bob@email.com' },
+  //       { primary: 'primary@email.com', funEmail: 'fun@email.com' }
+  //     ]);
+  //     expect(changeset.changes).toEqual([
+  //       { key: 'emails.1.funEmail', value: 'fun@email.com' },
+  //       { key: 'emails.1.primary', value: 'primary@email.com' }
+  //     ]);
+  //   });
+
+  //   it('can add a new object all at once, and edit it', () => {
+  //     const changeset = Changeset(initialData, userSchema);
+
+  //     changeset.set('emails.1', {
+  //       funEmail: 'fun@email.com',
+  //       primary: 'primary@email.com'
+  //     });
+
+  //     expect(changeset.get('emails.1.funEmail')).toEqual('fun@email.com');
+  //     expect(changeset.get('emails.1.primary')).toEqual('primary@email.com');
+  //     expect(changeset.get('emails')).toEqual([
+  //       { primary: 'bob@email.com' },
+  //       { primary: 'primary@email.com', funEmail: 'fun@email.com' }
+  //     ]);
+  //     expect(changeset.changes).toEqual([
+  //       {
+  //         key: 'emails.1',
+  //         value: { funEmail: 'fun@email.com', primary: 'primary@email.com' }
+  //       }
+  //     ]);
+
+  //     changeset.set('emails.1.primary', 'primary2@email.com');
+
+  //     expect(changeset.get('emails.1.primary')).toEqual('primary2@email.com');
+  //     expect(changeset.changes).toEqual([
+  //       {
+  //         key: 'emails.1',
+  //         value: {
+  //           primary: 'primary2@email.com',
+  //           funEmail: 'fun@email.com'
+  //         }
+  //       }
+  //     ]);
+  //     expect(changeset.get('emails')).toEqual([
+  //       { primary: 'bob@email.com' },
+  //       { primary: 'primary2@email.com', funEmail: 'fun@email.com' }
+  //     ]);
+  //   });
+
+  //   it('can edit a new object that was added after deleting an array entry', () => {
+  //     const changeset = Changeset({
+  //       emails: [
+  //         {
+  //           fun: 'fun0@email.com',
+  //           primary: 'primary0@email.com'
+  //         },
+  //         {
+  //           fun: 'fun1@email.com',
+  //           primary: 'primary1@email.com'
+  //         }
+  //       ]
+  //     });
+
+  //     changeset.set('emails.1', null);
+
+  //     expect(changeset.get('emails.0.fun')).toEqual('fun0@email.com');
+  //     expect(changeset.get('emails.0.primary')).toEqual('primary0@email.com');
+  //     expect(changeset.get('emails')).toEqual([
+  //       {
+  //         fun: 'fun0@email.com',
+  //         primary: 'primary0@email.com'
+  //       },
+  //       null
+  //     ]);
+  //     expect(changeset.changes).toEqual([
+  //       {
+  //         key: 'emails.1',
+  //         value: null
+  //       }
+  //     ]);
+
+  //     changeset.set('emails.1', {
+  //       fun: 'brandNew@email.com',
+  //       primary: 'brandNewPrimary@email.com'
+  //     });
+
+  //     expect(changeset.get('emails')).toEqual([
+  //       {
+  //         fun: 'fun0@email.com',
+  //         primary: 'primary0@email.com'
+  //       },
+  //       {
+  //         fun: 'brandNew@email.com',
+  //         primary: 'brandNewPrimary@email.com'
+  //       }
+  //     ]);
+  //     expect(changeset.changes).toEqual([
+  //       {
+  //         key: 'emails.1',
+  //         value: {
+  //           fun: 'brandNew@email.com',
+  //           primary: 'brandNewPrimary@email.com'
+  //         }
+  //       }
+  //     ]);
+  //   });
+
+  //   it('can edit an object with a key of value after another array entry has been deleted', () => {
+  //     const changeset = Changeset({
+  //       emails: [
+  //         {
+  //           fun: 'fun0@email.com',
+  //           primary: 'primary0@email.com',
+  //           value: 'the value'
+  //         },
+  //         {
+  //           fun: 'fun1@email.com',
+  //           primary: 'primary1@email.com',
+  //           value: 'some value'
+  //         }
+  //       ]
+  //     });
+
+  //     changeset.set('emails.1', null);
+
+  //     expect(changeset.get('emails')).toEqual([
+  //       {
+  //         fun: 'fun0@email.com',
+  //         primary: 'primary0@email.com',
+  //         value: 'the value'
+  //       },
+  //       null
+  //     ]);
+  //     expect(changeset.changes).toEqual([
+  //       {
+  //         key: 'emails.1',
+  //         value: null
+  //       }
+  //     ]);
+
+  //     expect(changeset.get('emails.0.fun')).toEqual('fun0@email.com');
+  //     expect(changeset.get('emails.0.primary')).toEqual('primary0@email.com');
+  //     // does not need to be unwrapped
+  //     expect(changeset.get('emails.0.value')).toEqual('the value');
+  //   });
+  // });
+
+  // describe('arrays of objects within nested objects', () => {
+  //   describe('#set', () => {
+  //     let initialData: { contact: { emails: Record<string, string>[] } } = {
+  //       contact: { emails: [] }
+  //     };
+
+  //     beforeEach(() => {
+  //       initialData = { contact: { emails: [{ primary: 'bob@email.com' }] } };
+  //     });
+
+  //     it('can modify properties on an entry', () => {
+  //       const changeset = Changeset(initialData, userSchema);
+
+  //       changeset.set('contact.emails.0.primary', 'fun@email.com');
+
+  //       expect(changeset.get('contact.emails.0.primary')).toEqual('fun@email.com');
+  //       expect(changeset.get('contact.emails').unwrap()).toEqual([{ primary: 'fun@email.com' }]);
+  //       expect(changeset.changes).toEqual([
+  //         { key: 'contact.emails.0.primary', value: 'fun@email.com' }
+  //       ]);
+  //     });
+
+  //     it('can add properties to an entry', () => {
+  //       const changeset = Changeset(initialData, userSchema);
+
+  //       changeset.set('contact.emails.0.funEmail', 'fun@email.com');
+
+  //       expect(changeset.get('contact.emails.0.funEmail')).toEqual('fun@email.com');
+  //       expect(changeset.changes).toEqual([
+  //         { key: 'contact.emails.0.funEmail', value: 'fun@email.com' }
+  //       ]);
+  //       expect(changeset.get('contact.emails').unwrap()).toEqual([
+  //         { primary: 'bob@email.com', funEmail: 'fun@email.com' }
+  //       ]);
+  //     });
+
+  //     it('can add new properties to new entries', () => {
+  //       const changeset = Changeset(initialData, userSchema);
+
+  //       changeset.set('contact.emails.1.funEmail', 'fun@email.com');
+  //       changeset.set('contact.emails.1.primary', 'primary@email.com');
+
+  //       expect(changeset.get('contact.emails.1.funEmail')).toEqual('fun@email.com');
+  //       expect(changeset.get('contact.emails.1.primary')).toEqual('primary@email.com');
+  //       expect(changeset.get('contact.emails').unwrap()).toEqual([
+  //         { primary: 'bob@email.com' },
+  //         { primary: 'primary@email.com', funEmail: 'fun@email.com' }
+  //       ]);
+  //       expect(changeset.changes).toEqual([
+  //         { key: 'contact.emails.1.funEmail', value: 'fun@email.com' },
+  //         { key: 'contact.emails.1.primary', value: 'primary@email.com' }
+  //       ]);
+  //     });
+
+  //     it('can add a new object all at once, and edit it', () => {
+  //       const changeset = Changeset(initialData, userSchema);
+
+  //       changeset.set('contact.emails.1', {
+  //         funEmail: 'fun@email.com',
+  //         primary: 'primary@email.com'
+  //       });
+
+  //       expect(changeset.get('contact.emails.1.funEmail')).toEqual('fun@email.com');
+  //       expect(changeset.get('contact.emails.1.primary')).toEqual('primary@email.com');
+  //       expect(changeset.get('contact.emails').unwrap()).toEqual([
+  //         { primary: 'bob@email.com' },
+  //         { primary: 'primary@email.com', funEmail: 'fun@email.com' }
+  //       ]);
+  //       expect(changeset.changes).toEqual([
+  //         {
+  //           key: 'contact.emails.1',
+  //           value: { funEmail: 'fun@email.com', primary: 'primary@email.com' }
+  //         }
+  //       ]);
+
+  //       changeset.set('contact.emails.1.primary', 'primary2@email.com');
+
+  //       expect(changeset.get('contact.emails.1.primary')).toEqual('primary2@email.com');
+  //       expect(changeset.changes).toEqual([
+  //         {
+  //           key: 'contact.emails.1',
+  //           value: {
+  //             primary: 'primary2@email.com',
+  //             funEmail: 'fun@email.com'
+  //           }
+  //         }
+  //       ]);
+  //       expect(changeset.get('contact.emails').unwrap()).toEqual([
+  //         { primary: 'bob@email.com' },
+  //         { primary: 'primary2@email.com', funEmail: 'fun@email.com' }
+  //       ]);
+  //     });
+
+  //     it('can edit a new object that was added after deleting an array entry', () => {
+  //       const changeset = Changeset({
+  //         contacts: {
+  //           emails: [
+  //             {
+  //               fun: 'fun0@email.com',
+  //               primary: 'primary0@email.com'
+  //             },
+  //             {
+  //               fun: 'fun1@email.com',
+  //               primary: 'primary1@email.com'
+  //             }
+  //           ]
+  //         }
+  //       });
+
+  //       changeset.set('contacts.emails.1', null);
+
+  //       expect(changeset.get('contacts.emails').unwrap()).toEqual([
+  //         {
+  //           fun: 'fun0@email.com',
+  //           primary: 'primary0@email.com'
+  //         },
+  //         null
+  //       ]);
+  //     });
+  //   });
+  // });
+
+  // it('#set works for nested when the root key is "value"', () => {
+  //   dummyModel.value = {};
+  //   dummyModel.org = {};
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('value.short', 'foo');
+
+  //   expect(dummyChangeset.get('value.short')).toBe('foo');
+  //   expect(dummyModel.value).toEqual({});
+
+  //   const changes = dummyChangeset.changes;
+  //   const expectedChanges = [{ key: 'value.short', value: 'foo' }];
+  //   expect(changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.value).toEqual({ short: 'foo' });
+  //   expect(dummyChangeset.org).toEqual({});
+
+  //   dummyChangeset.execute();
+
+  //   expect(dummyModel.value.short).toBe('foo');
+  // });
+
+  // it('nested objects can be replaced with different ones without changing the nested return values', () => {
+  //   dummyModel['org'] = { usa: { ny: 'ny' } };
+
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('org', { usa: { ca: 'ca' } });
+
+  //   expect(dummyChangeset.get('org')).toEqual({ usa: { ca: 'ca', ny: undefined } });
+  //   expect(dummyChangeset.get('org.usa')).toEqual({ ca: 'ca', ny: undefined });
+  //   expect(dummyChangeset.get('org.usa.ca')).toBe('ca');
+  //   expect(dummyChangeset.get('org.usa.ny')).toBeUndefined();
+  // });
+
+  // it('nested objects can be replaced with different ones as classes', () => {
+  //   class Country {
+  //     details: object;
+  //     constructor(details: object) {
+  //       this.details = details;
+  //     }
+  //   }
+  //   dummyModel['org'] = new Country({ usa: { ny: 'ny' } });
+
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('org', new Country({ usa: { ca: 'ca' } }));
+
+  //   expect(dummyChangeset.get('org')).toEqual(new Country({ usa: { ca: 'ca', ny: undefined } }));
+  //   expect(dummyChangeset.get('org.details')).toEqual({ usa: { ca: 'ca', ny: undefined } });
+  //   expect(dummyChangeset.get('org.details.usa')).toEqual({ ca: 'ca', ny: undefined });
+  //   expect(dummyChangeset.get('org.details.usa.ca')).toBe('ca');
+  //   expect(dummyChangeset.get('org.details.usa.ny')).toBeUndefined();
+  // });
+
+  // it('#set doesnt lose sibling keys', () => {
+  //   dummyModel['org'] = {
+  //     usa: {
+  //       mn: 'mn',
+  //       ny: 'ny',
+  //       nz: 'nz'
+  //     },
+  //     landArea: 100
+  //   };
+
+  //   const c: Record<string, any> = Changeset(dummyModel, userSchema);
+  //   c.set('org.usa.ny', 'NY');
+
+  //   expect(dummyModel.org.usa.ny).toBe('ny');
+  //   expect(c.org.usa.ny).toBe('NY');
+  //   expect(c.get('org.usa.ny')).toBe('NY');
+  //   expect(c.get('org.usa.mn')).toBe('mn');
+  //   expect(c.get('org.usa.nz')).toBe('nz');
+  //   expect(c.get('org.landArea')).toBe(100);
+
+  //   // set again
+  //   c.set('org.usa.ny', 'nye');
+
+  //   expect(dummyModel.org.usa.ny).toBe('ny');
+  //   expect(c.org.usa.ny).toBe('nye');
+  //   expect(c.get('org.usa.ny')).toBe('nye');
+  //   expect(c.get('org.usa.mn')).toBe('mn');
+  //   expect(c.get('org.usa.nz')).toBe('nz');
+  //   expect(c.get('org.landArea')).toBe(100);
+  // });
+
+  // it('#set adds a change if the key is an object', () => {
+  //   dummyModel['org'] = {
+  //     usa: {
+  //       mn: 'mn',
+  //       ny: 'ny',
+  //       nz: 'nz'
+  //     },
+  //     landArea: 100
+  //   };
+
+  //   const c: any = Changeset(dummyModel, userSchema);
+  //   c.set('org.usa.ny', 'NY');
+
+  //   expect(dummyModel.org.usa.ny).toBe('ny');
+  //   expect(c.org.usa.ny).toBe('NY');
+  //   expect(c.get('org.usa.ny')).toBe('NY');
+  //   expect(c.get('org.usa.mn')).toBe('mn');
+  //   expect(c.get('org.usa.nz')).toBe('nz');
+  //   expect(c.get('org.landArea')).toBe(100);
+
+  //   const expectedChanges = [{ key: 'org.usa.ny', value: 'NY' }];
+  //   const changes = c.changes;
+
+  //   expect(changes).toEqual(expectedChanges);
+  // });
+
+  // it('#set use native setters with nested doesnt work', () => {
+  //   dummyModel['org'] = {
+  //     usa: {
+  //       ny: 'ny'
+  //     }
+  //   };
+
+  //   const c = Changeset(dummyModel, userSchema);
+  //   set(c, 'org.usa.ny', 'foo');
+
+  //   expect(dummyModel.org.usa.ny).toBe('foo');
+  //   expect(c.get('org.usa.ny')).toBe('foo');
+
+  //   const changes = c.changes;
+  //   expect(changes).toEqual([]);
+  // });
+
+  // it('#set use native setters at single level', () => {
+  //   dummyModel.org = 'ny';
+
+  //   const c = Changeset(dummyModel, userSchema);
+  //   c.org = 'foo';
+
+  //   expect(dummyModel.org).toBe('ny');
+  //   expect(c.org).toBe('foo');
+
+  //   const changes = c.changes;
+  //   expect(changes).toEqual([{ key: 'org', value: 'foo' }]);
+  // });
+
+  // it('#set adds a change if value is an object', () => {
+  //   class Moment {
+  //     date: unknown;
+  //     constructor(date: Date) {
+  //       this.date = date;
+  //     }
+  //   }
+  //   const c = Changeset(dummyModel, userSchema);
+  //   const d = new Date();
+  //   const momentInstance = new Moment(d);
+  //   c.set('startDate', momentInstance);
+
+  //   const expectedChanges = [{ key: 'startDate', value: momentInstance }];
+  //   const changes = c.changes;
+
+  //   expect(changes).toEqual(expectedChanges);
+
+  //   let newValue = c.get('startDate');
+  //   expect(newValue.date).toEqual(momentInstance.date);
+  //   expect(newValue instanceof Moment).toBeTruthy();
+  //   expect(newValue.date).toEqual(d);
+
+  //   newValue = c.startDate;
+  //   expect(newValue.date).toEqual(momentInstance.date);
+  //   expect(newValue instanceof Moment).toBeTruthy();
+  //   expect(newValue.date).toEqual(d);
+  // });
+
+  // it('#set supports `undefined`', () => {
+  //   const model = { name: 'foo' };
+  //   const dummyChangeset = Changeset(model);
+
+  //   dummyChangeset.set('name', undefined);
+  //   expect(dummyChangeset.name).toBeUndefined();
+  //   expect(dummyChangeset.changes).toEqual([{ key: 'name', value: undefined }]);
+  // });
+
+  // it('#set does not add a change if new value equals old value', () => {
+  //   const model = { name: 'foo' };
+  //   const dummyChangeset = Changeset(model);
+
+  //   dummyChangeset.set('name', 'foo');
+  //   expect(dummyChangeset.changes).toEqual([]);
+  // });
+
+  // it('#set does not add a change if new value equals old value and `skipValidate` is true', () => {
+  //   const model = { name: 'foo' };
+  //   const dummyChangeset = Changeset(model, null, null, { skipValidate: true });
+
+  //   expect(dummyChangeset.isValid).toEqual(true);
+
+  //   dummyChangeset.set('name', 'foo');
+
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  // });
+
+  // it('#set removes a change if set back to original value', () => {
+  //   const model = { name: 'foo' };
+  //   const dummyChangeset = Changeset(model);
+
+  //   dummyChangeset.set('name', 'bar');
+  //   expect(dummyChangeset.changes).toEqual([{ key: 'name', value: 'bar' }]);
+
+  //   dummyChangeset.set('name', 'foo');
+  //   expect(dummyChangeset.changes).toEqual([]);
+  // });
+
+  // it('#set removes a change if set back to original value in nested context', () => {
+  //   const model = { name: { email: 'foo' } };
+  //   const dummyChangeset = Changeset(model);
+  //   dummyChangeset.safeGet = get;
+
+  //   dummyChangeset.set('name.email', 'bar');
+  //   expect(dummyChangeset.changes).toEqual([{ key: 'name.email', value: 'bar' }]);
+
+  //   dummyChangeset.set('name.email', 'foo');
+  //   expect(dummyChangeset.changes).toEqual([]);
+  // });
+
+  // it('#set does add a change if invalid', () => {
+  //   const expectedErrors = [
+  //     { key: 'name', validation: 'too short', value: 'a' },
+  //     { key: 'password', validation: ['foo', 'bar'], value: false }
+  //   ];
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('name', 'a');
+  //   dummyChangeset.set('password', false);
+  //   const changes = dummyChangeset.changes;
+  //   const errors = dummyChangeset.errors;
+  //   const isValid = dummyChangeset.isValid;
+  //   const isInvalid = dummyChangeset.isInvalid;
+
+  //   const expectedChanges = [
+  //     { key: 'name', value: 'a' },
+  //     { key: 'password', value: false }
+  //   ];
+  //   expect(changes).toEqual(expectedChanges);
+  //   expect(errors).toEqual(expectedErrors);
+  //   expect(isValid).toEqual(false);
+  //   expect(isInvalid).toBeTruthy();
+  // });
+
+  // it('#set adds the change without validation if `skipValidate` option is set', () => {
+  //   const expectedChanges = [{ key: 'password', value: false }];
+
+  //   const dummyChangeset = Changeset(dummyModel, userSchema), null, {
+  //     skipValidate: true
+  //   });
+
+  //   expect(dummyChangeset.isValid).toEqual(true);
+
+  //   dummyChangeset.set('password', false);
+  //   const changes = dummyChangeset.changes;
+
+  //   expect(changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  // });
+
+  // it('#set adds errors if undefined value', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedResult = [{ key: 'name', validation: 'too short', value: undefined }];
+  //   dummyChangeset.set('name', undefined);
+
+  //   expect(dummyChangeset.errors).toEqual(expectedResult);
+  //   expect(dummyChangeset.get('errors')).toEqual(expectedResult);
+  // });
+
+  // it('#set if trigger null value', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedResult = [{ key: 'name', validation: 'too short', value: null }];
+  //   dummyChangeset.set('name', null);
+
+  //   expect(dummyChangeset.errors).toEqual(expectedResult);
+  //   expect(dummyChangeset.get('errors')).toEqual(expectedResult);
+  // });
+
+  // it('#set if trigger empty string value', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedResult = [{ key: 'name', validation: 'too short', value: '' }];
+  //   dummyChangeset.set('name', '');
+
+  //   expect(dummyChangeset.errors).toEqual(expectedResult);
+  //   expect(dummyChangeset.get('errors')).toEqual(expectedResult);
+  // });
+
+  // it('#set should remove nested changes when setting roots', () => {
+  //   dummyModel['org'] = {
+  //     usa: {
+  //       ny: 'ny',
+  //       ca: 'ca'
+  //     }
+  //   };
+
+  //   const c = Changeset(dummyModel, userSchema);
+  //   c.set('org.usa.ny', 'foo');
+  //   c.set('org.usa.ca', 'bar');
+  //   c.set('org', 'no usa for you');
+
+  //   const actual = c.changes;
+  //   const expectedResult = [{ key: 'org', value: 'no usa for you' }];
+  //   expect(actual).toEqual(expectedResult);
+  // });
+
+  // it('#set should handle bulk replace', () => {
+  //   dummyModel['org'] = {
+  //     usa: {
+  //       ny: 'ny',
+  //       ca: 'ca'
+  //     }
+  //   };
+
+  //   const c = Changeset(dummyModel, userSchema);
+  //   c.set('org', {
+  //     isCompliant: true,
+  //     usa: {
+  //       ca: 'il',
+  //       ny: 'wi'
+  //     }
+  //   });
+
+  //   let actual = c.changes;
+  //   let expectedResult = [
+  //     {
+  //       key: 'org',
+  //       value: {
+  //         isCompliant: true,
+  //         usa: {
+  //           ca: 'il',
+  //           ny: 'wi'
+  //         }
+  //       }
+  //     }
+  //   ];
+
+  //   expect(actual).toEqual(expectedResult);
+
+  //   c.set('org.isCompliant', false);
+
+  //   actual = c.changes;
+  //   expectedResult = [
+  //     {
+  //       key: 'org',
+  //       value: {
+  //         isCompliant: false,
+  //         usa: {
+  //           ca: 'il',
+  //           ny: 'wi'
+  //         }
+  //       }
+  //     }
+  //   ];
+
+  //   expect(actual).toEqual(expectedResult);
+  // });
+
+  // it('#set works after save', () => {
+  //   delete dummyModel.save;
+
+  //   dummyModel['org'] = {
+  //     usa: {
+  //       mn: 'mn',
+  //       ny: 'ny'
+  //     }
+  //   };
+
+  //   const c = Changeset(dummyModel, userSchema);
+  //   c.set('org.usa.ny', 'NY');
+  //   c.set('org.usa.mn', 'MN');
+
+  //   expect(c.get('org.usa.ny')).toBe('NY');
+  //   expect(c.get('org.usa.mn')).toBe('MN');
+  //   expect(dummyModel.org.usa.ny).toBe('ny');
+  //   expect(dummyModel.org.usa.mn).toBe('mn');
+
+  //   c.save();
+
+  //   expect(c.get('org.usa.ny')).toBe('NY');
+  //   expect(c.get('org.usa.mn')).toBe('MN');
+  //   expect(dummyModel.org.usa.ny).toBe('NY');
+  //   expect(dummyModel.org.usa.mn).toBe('MN');
+
+  //   c.set('org.usa.ny', 'nil');
+
+  //   expect(c.get('org.usa.ny')).toBe('nil');
+  //   expect(c.get('org.usa.mn')).toBe('MN');
+  //   expect(dummyModel.org.usa.ny).toBe('NY');
+  //   expect(dummyModel.org.usa.mn).toBe('MN');
+
+  //   c.save();
+
+  //   expect(c.get('org.usa.ny')).toBe('nil');
+  //   expect(c.get('org.usa.mn')).toBe('MN');
+  //   expect(dummyModel.org.usa.ny).toBe('nil');
+  //   expect(dummyModel.org.usa.mn).toBe('MN');
+
+  //   c.set('org.usa.ny', 'nil2');
+  //   c.set('org.usa.mn', 'undefined');
+
+  //   expect(c.get('org.usa.ny')).toBe('nil2');
+  //   expect(c.get('org.usa.mn')).toBe('undefined');
+  //   expect(dummyModel.org.usa.ny).toBe('nil');
+  //   expect(dummyModel.org.usa.mn).toBe('MN');
+
+  //   c.save();
+
+  //   expect(c.get('org.usa.ny')).toBe('nil2');
+  //   expect(c.get('org.usa.mn')).toBe('undefined');
+  //   expect(dummyModel.org.usa.ny).toBe('nil2');
+  //   expect(dummyModel.org.usa.mn).toBe('undefined');
+  // });
+
+  // it('#set works for deep set and access', async () => {
+  //   const resource = {
+  //     styles: {
+  //       colors: {
+  //         main: {
+  //           sync: true,
+  //           color: '#3D3D3D',
+  //           contrastColor: '#FFFFFF',
+  //           syncedColor: '#575757',
+  //           syncedContrastColor: '#FFFFFF'
+  //         },
+  //         accent: {
+  //           sync: true,
+  //           color: '#967E6E',
+  //           contrastColor: '#ffffff',
+  //           syncedColor: '#967E6E',
+  //           syncedContrastColor: '#ffffff'
+  //         },
+  //         ambient: {
+  //           sync: true,
+  //           color: '#FFFFFF',
+  //           contrastColor: '#3D3D3D',
+  //           syncedColor: '#FFFFFF',
+  //           syncedContrastColor: '#575757'
+  //         }
+  //       }
+  //     }
+  //   };
+
+  //   const changeset = Changeset(resource);
+
+  //   changeset.set('styles.colors.main.sync', false);
+
+  //   const result = changeset.get('styles.colors.main');
+  //   expect(result.sync).toEqual(false);
+  // });
+
+  // it('#set nested objects at various level of tree will return correct values', () => {
+  //   dummyModel['org'] = {
+  //     asia: { sg: '_initial' }, // for the sake of disambiguating nulls
+  //     usa: {
+  //       ca: null,
+  //       ny: null,
+  //       ma: { name: null }
+  //     }
+  //   };
+
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   expect(dummyChangeset.get('org.asia.sg')).toBe('_initial');
+
+  //   dummyChangeset.set('org.asia.sg', 'sg');
+  //   expect(dummyChangeset.get('org.asia.sg')).toBe('sg');
+
+  //   dummyChangeset.get('org.asia').set('sg', 'SG');
+  //   expect(dummyChangeset.get('org.asia.sg')).toBe('SG');
+
+  //   dummyChangeset.get('org').set('asia.sg', 'sg');
+  //   expect(dummyChangeset.get('org.asia.sg')).toBe('sg');
+
+  //   expect(dummyChangeset.get('org').get('asia.sg')).toBe('sg');
+  // });
+
+  // it('it accepts async validations', async () => {
+  //   delete dummyModel.save;
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const expectedChanges = [{ key: 'async', value: true }];
+  //   const expectedError = { async: { validation: 'is invalid', value: 'is invalid' } };
+
+  //   dummyChangeset.set('async', true);
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+
+  //   dummyChangeset.set('async', 'is invalid');
+  //   expect(dummyChangeset.error).toEqual({});
+
+  //   await dummyChangeset.validate();
+  //   expect(dummyChangeset.error).toEqual(expectedError);
+
+  //   await dummyChangeset.save();
+  //   // save clears errors
+  //   expect(dummyChangeset.error).toEqual({});
+  // });
+
+  // it('it clears errors when setting to original value', () => {
+  //   dummyModel.name = 'Jim Bob';
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('name', '');
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   expect(dummyChangeset.isValid).toEqual(false);
+  //   dummyChangeset.set('name', 'Jim Bob');
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect(dummyChangeset.isInvalid).toEqual(false);
+  // });
+
+  // it('it clears errors when setting to original value when nested', async () => {
+  //   set(dummyModel, 'org', {
+  //     usa: { ny: 'vaca' }
+  //   });
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('org.usa.ny', '');
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   dummyChangeset.set('org.usa.ny', 'vaca');
+  //   expect(dummyChangeset.isValid).toBeTruthy();
+  //   expect(dummyChangeset.isInvalid).toEqual(false);
+  // });
+
+  // test('it clears errors when setting to original value when nested Booleans', async () => {
+  //   set(dummyModel, 'org', {
+  //     isCompliant: true
+  //   });
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('org.isCompliant', false);
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   dummyChangeset.set('org.isCompliant', true);
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect(dummyChangeset.isInvalid).toEqual(false);
+  // });
+
+  // it('#set should delete nested changes when equal', () => {
+  //   dummyModel['org'] = {
+  //     usa: { ny: 'i need a vacation' }
+  //   };
+
+  //   const c = Changeset(dummyModel, userSchema), dummyValidations);
+  //   c.set('org.usa.br', 'whoop');
+
+  //   const actual = get(c, 'change.org.usa.ny');
+  //   const expectedResult = undefined;
+  //   expect(actual).toEqual(expectedResult);
+  // });
+
+  // it('#set works when replacing an Object with an primitive', () => {
+  //   const model = { foo: { bar: { baz: 42 } } };
+
+  //   const c: any = Changeset(model);
+  //   expect(c.foo.bar.baz).toEqual(model.foo.bar.baz);
+
+  //   c.set('foo', 'not an object anymore');
+  //   c.execute();
+  //   expect(c.get('foo')).toEqual(model.foo);
+  // });
+
+  // /**
+  //  * #prepare
+  //  */
+
+  // it('#prepare provides callback to modify changes', () => {
+  //   const date = new Date();
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('first_name', 'foo');
+  //   dummyChangeset.set('date_of_birth', date);
+  //   dummyChangeset.prepare(changes => {
+  //     const modified: Record<string, any> = {};
+
+  //     for (let key in changes) {
+  //       modified[(key as string).replace(/_/g, '-')] = changes[key];
+  //     }
+
+  //     return modified;
+  //   });
+  //   const changeKeys = dummyChangeset.changes.map(change => get(change, 'key'));
+
+  //   expect(changeKeys).toEqual(['first-name', 'date-of-birth']);
+  //   dummyChangeset.execute();
+  //   expect(dummyModel['first-name']).toEqual('foo');
+  //   expect(dummyModel['date-of-birth']).toEqual(date);
+  // });
+
+  // it('#prepare throws if callback does not return object', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('first_name', 'foo');
+
+  //   expect(() => dummyChangeset.prepare(() => null)).toThrow();
+  // });
+
+  // it('#prepare works with initial model containing an object property', () => {
+  //   const dummyChangeset = Changeset({ obj: {} });
+
+  //   dummyChangeset.get('obj').unwrap();
+  //   dummyChangeset.prepare(function(changes) {
+  //     return changes;
+  //   });
+
+  //   expect(dummyChangeset.isPristine).toEqual(true);
+  // });
+
+  // /**
+  //  * #execute
+  //  */
+
+  // it('#execute applies changes to content if valid', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('name', 'foo');
+
+  //   expect(dummyModel.name).toBeUndefined();
+  //   expect(dummyChangeset.isValid).toBeTruthy();
+  //   expect(dummyChangeset.isDirty).toBe(true);
+  //   dummyChangeset.execute();
+  //   expect(dummyModel.name).toBe('foo');
+  //   expect(dummyChangeset.isDirty).toBe(false);
+  // });
+
+  // it('#execute does not apply changes to content if invalid', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('name', 'a');
+
+  //   expect(dummyModel.name).toBeUndefined();
+  //   expect(dummyChangeset.isInvalid).toBeTruthy();
+  //   dummyChangeset.execute();
+  //   expect(dummyModel.name).toBeUndefined();
+  // });
+
+  // it('#execute keeps prototype of set object', function() {
+  //   class DogTag {}
+
+  //   const dog = new DogTag();
+  //   const originalProto = Object.getPrototypeOf(dog);
+
+  //   const model: Record<string, any> = {};
+  //   const c = Changeset(model);
+  //   c.set('dog', dog);
+
+  //   const condition = c.dog instanceof DogTag;
+  //   expect(condition).toBeTruthy();
+
+  //   c.execute();
+
+  //   const modelDog = model.dog instanceof DogTag;
+  //   expect(modelDog).toBeTruthy();
+  //   expect(Object.getPrototypeOf(model.dog)).toEqual(originalProto);
+  // });
+
+  // it('#execute does not remove original nested objects', function() {
+  //   class DogTag {}
+
+  //   const dog: any = {};
+  //   dog.info = new DogTag();
+  //   dog.info.name = 'mishka';
+  //   dog.info.breed = 'husky';
+
+  //   const c = Changeset(dog);
+  //   c.set('info.name', 'laika');
+
+  //   c.execute();
+
+  //   const condition = dog.info instanceof DogTag;
+  //   expect(condition).toBeTruthy();
+  //   expect(dog.info.name).toEqual('laika');
+  // });
+
+  // [
+  //   {
+  //     model: () => ({ org: { usa: { ny: '', ca: '' } } }),
+  //     setCalls: [
+  //       ['org.usa.ny', 'foo'],
+  //       ['org.usa.ca', 'bar'],
+  //       ['org', 'no usa for you']
+  //     ],
+  //     result: () => ({ org: 'no usa for you' })
+  //   },
+  //   {
+  //     model: () => ({ org: { usa: { ny: '', ca: '' } } }),
+  //     setCalls: [
+  //       ['org.usa.ny', 'foo'],
+  //       ['org', 'no usa for you'],
+  //       ['org.usa.ca', 'bar']
+  //     ],
+  //     result: () => ({ org: { usa: { ca: 'bar', ny: '' } } })
+  //   },
+  //   {
+  //     model: () => ({ org: { usa: { ny: '', ca: '' } } }),
+  //     setCalls: [
+  //       ['org', 'no usa for you'],
+  //       ['org.usa.ny', 'foo'],
+  //       ['org.usa.ca', 'bar']
+  //     ],
+  //     result: () => ({ org: { usa: { ny: 'foo', ca: 'bar' } } })
+  //   }
+  // ].forEach(({ model, setCalls, result }, i) => {
+  //   it(`#execute - table-driven test ${i + 1}`, () => {
+  //     const m = model();
+  //     const c = Changeset(m);
+
+  //     setCalls.forEach(([k, v]) => c.set(k, v));
+  //     c.execute();
+
+  //     const actual = m;
+  //     const expectedResult = result();
+  //     expect(actual).toEqual(expectedResult);
+  //   });
+  // });
+
+  // it('#execute it works with nested keys', () => {
+  //   const expectedResult = {
+  //     org: {
+  //       asia: { sg: 'sg' },
+  //       usa: {
+  //         ca: 'ca',
+  //         ny: 'ny',
+  //         ma: { name: 'Massachusetts' }
+  //       }
+  //     }
+  //   };
+  //   dummyModel['org'] = {
+  //     asia: { sg: null },
+  //     usa: {
+  //       ca: null,
+  //       ny: null,
+  //       ma: { name: null }
+  //     }
+  //   };
+
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('org.asia.sg', 'sg');
+  //   dummyChangeset.set('org.usa.ca', 'ca');
+  //   dummyChangeset.set('org.usa.ny', 'ny');
+  //   dummyChangeset.set('org.usa.ma', { name: 'Massachusetts' });
+  //   dummyChangeset.execute();
+  //   expect(dummyChangeset.change).toEqual({});
+  //   expect(get(dummyChangeset, '_content.org')).toEqual(expectedResult.org);
+  //   expect(dummyModel.org).toEqual(expectedResult.org);
+  // });
+
+  // it('#execute calls registered callbacked', function() {
+  //   expect.assertions(1);
+
+  //   const dog: any = {};
+
+  //   const c = Changeset(dog);
+  //   function callback() {
+  //     expect(true).toBeTruthy();
+  //   }
+
+  //   c.on('execute', callback);
+  //   c.on('execute-2', callback);
+
+  //   c.execute();
+  // });
+
+  // it('#execute works with an object with value key', () => {
+  //   dummyModel.size = {
+  //     value: 0
+  //   };
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('size.value', 1001);
+  //   dummyChangeset.set('size.power10', 10);
+
+  //   expect(dummyModel.size.value).toEqual(0);
+  //   expect(dummyModel.size.power10).toBeUndefined();
+
+  //   dummyChangeset.execute();
+
+  //   expect(dummyModel.size.value).toBe(1001);
+  //   expect(dummyModel.size.power10).toBe(10);
+  // });
+
+  // it('#execute works if leaf property wasnt set before', () => {
+  //   dummyModel.size = {};
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('size.value', 1001);
+
+  //   expect(dummyModel.size).toEqual({});
+
+  //   dummyChangeset.execute();
+
+  //   expect(dummyModel.size.value).toBe(1001);
+  //   expect(dummyModel.size.power10).toBeUndefined();
+  // });
+
+  // it('#execute works if root property wasnt set before', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('size.value', 1001);
+
+  //   expect(dummyModel.size).toBeUndefined();
+
+  //   dummyChangeset.execute();
+
+  //   expect(dummyModel.size.value).toBe(1001);
+  //   expect(dummyModel.size.power10).toBeUndefined();
+  // });
+
+  // test('execute returns correct object after setting value on empty initial object', async function() {
+  //   let c = Changeset({});
+
+  //   c.set('country', 'usa');
+
+  //   expect(c.execute().data).toEqual({
+  //     country: 'usa'
+  //   });
+
+  //   c.set('org.usa.ny', 'any value');
+
+  //   expect(c.execute().data).toEqual({
+  //     country: 'usa',
+  //     org: {
+  //       usa: {
+  //         ny: 'any value'
+  //       }
+  //     }
+  //   });
+  //   c.set('org.usa.il', '2nd value');
+
+  //   expect(c.execute().data).toEqual({
+  //     country: 'usa',
+  //     org: {
+  //       usa: {
+  //         ny: 'any value',
+  //         il: '2nd value'
+  //       }
+  //     }
+  //   });
+  // });
+
+  // /**
+  //  * #save
+  //  */
+
+  // it('#save proxies to content', done => {
+  //   let result;
+  //   let options;
+  //   dummyModel.save = (dummyOptions: Record<string, any>) => {
+  //     result = 'ok';
+  //     options = dummyOptions;
+  //     return Promise.resolve('saveResult');
+  //   };
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('name', 'foo');
+
+  //   expect(result).toBeUndefined();
+  //   const promise = dummyChangeset.save({ foo: 'test options' });
+  //   expect(result).toEqual('ok');
+  //   expect(dummyChangeset.change).toEqual({});
+  //   expect(options).toEqual({ foo: 'test options' });
+  //   expect(!!promise && typeof promise.then === 'function').toBeTruthy();
+  //   promise
+  //     .then(saveResult => {
+  //       expect(saveResult).toEqual('saveResult');
+  //     })
+  //     .finally(() => done());
+  // });
+
+  // it('#save handles non-promise proxy content', done => {
+  //   let result;
+  //   let options;
+  //   dummyModel.save = (dummyOptions: Record<string, any>) => {
+  //     result = 'ok';
+  //     options = dummyOptions;
+  //     return Promise.resolve('saveResult');
+  //   };
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('name', 'foo');
+
+  //   expect(result).toBe(undefined);
+  //   const promise = dummyChangeset.save({ foo: 'test options' });
+  //   expect(result).toBe('ok');
+  //   expect(options).toEqual({ foo: 'test options' });
+  //   expect(!!promise && typeof promise.then === 'function').toBeTruthy();
+  //   promise
+  //     .then(saveResult => {
+  //       expect(saveResult).toBe('saveResult');
+  //     })
+  //     .finally(() => done());
+  // });
+
+  // it('#save handles rejected proxy content', done => {
+  //   expect.assertions(1);
+
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+
+  //   dummyModel['save'] = () => {
+  //     return Promise.reject(new Error('some ember data error'));
+  //   };
+
+  //   dummyChangeset
+  //     .save()
+  //     .then(() => {
+  //       expect(false).toBeTruthy();
+  //     })
+  //     .catch(error => {
+  //       expect(error.message).toEqual('some ember data error');
+  //     })
+  //     .finally(() => done());
+  // });
+
+  // it('#save restores values on content after rejected Promise if user calls unexecute', done => {
+  //   expect.assertions(2);
+
+  //   dummyModel.name = 'previous';
+  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+
+  //   dummyModel['save'] = () => {
+  //     dummyModel.errors = [
+  //       {
+  //         message: 'oops I did it again'
+  //       }
+  //     ];
+  //     return Promise.reject(new Error('some ember data error'));
+  //   };
+
+  //   dummyChangeset.set('name', 'new');
+
+  //   dummyChangeset
+  //     .save()
+  //     .then(() => {
+  //       expect(false).toBeTruthy();
+  //     })
+  //     .catch(() => {
+  //       dummyChangeset.unexecute();
+  //     })
+  //     .finally(() => {
+  //       expect(dummyModel.name).toEqual('previous');
+  //       expect(dummyModel.errors).toEqual([
+  //         {
+  //           message: 'oops I did it again'
+  //         }
+  //       ]);
+  //       done();
+  //     });
+  // });
+
+  // it('#save proxies to content even if it does not implement #save', done => {
+  //   const person = { name: 'Jim' };
+  //   const dummyChangeset = Changeset(person);
+  //   dummyChangeset.set('name', 'foo');
+
+  //   return dummyChangeset.save().then(() => {
+  //     expect(person.name).toBe('foo');
+  //     done();
+  //   });
+  // });
+
+  // /**
+  //  * #merge
+  //  */
+
+  // it('#merge merges 2 valid changesets', () => {
+  //   const dummyChangesetA = Changeset(dummyModel, userSchema);
+  //   const dummyChangesetB = Changeset(dummyModel, userSchema);
+  //   dummyChangesetA.set('firstName', 'Jim');
+  //   dummyChangesetB.set('lastName', 'Bob');
+  //   const dummyChangesetC = dummyChangesetA.merge(dummyChangesetB);
+  //   const expectedChanges = [
+  //     { key: 'firstName', value: 'Jim' },
+  //     { key: 'lastName', value: 'Bob' }
+  //   ];
+
+  //   expect(dummyChangesetC.changes).toEqual(expectedChanges);
+  //   expect(dummyChangesetA.changes).toEqual([{ key: 'firstName', value: 'Jim' }]);
+  //   expect(dummyChangesetB.changes).toEqual([{ key: 'lastName', value: 'Bob' }]);
+  // });
+
+  // it('#merge merges invalid changesets', () => {
+  //   const dummyChangesetA = Changeset(dummyModel, userSchema));
+  //   const dummyChangesetB = Changeset(dummyModel, userSchema));
+  //   const dummyChangesetC = Changeset(dummyModel, userSchema));
+  //   dummyChangesetA.set('age', 21);
+  //   dummyChangesetA.set('name', 'a');
+  //   dummyChangesetB.set('name', 'Tony Stark');
+  //   dummyChangesetC.set('name', 'b');
+
+  //   let dummyChangesetD = dummyChangesetA.merge(dummyChangesetB);
+  //   dummyChangesetD = dummyChangesetD.merge(dummyChangesetC);
+
+  //   const expectedChanges = [
+  //     { key: 'age', value: 21 },
+  //     { key: 'name', value: 'b' }
+  //   ];
+  //   const expectedErrors = [{ key: 'name', validation: 'too short', value: 'b' }];
+
+  //   expect(dummyChangesetA.isInvalid).toEqual(true);
+  //   expect(dummyChangesetB.isValid).toEqual(true);
+  //   expect(dummyChangesetC.isInvalid).toEqual(true);
+  //   expect(dummyChangesetD.isInvalid).toEqual(true);
+  //   expect(dummyChangesetD.changes).toEqual(expectedChanges);
+  //   expect(dummyChangesetD.errors).toEqual(expectedErrors);
+  // });
+
+  // it('#merge does not merge a changeset with a non-changeset', () => {
+  //   const dummyChangesetA = Changeset(dummyModel, userSchema));
+  //   const dummyChangesetB = Changeset({ _changes: { name: 'b' } });
+  //   dummyChangesetA.set('name', 'a');
+
+  //   expect(() => dummyChangesetA.merge(dummyChangesetB)).toThrow();
+  // });
+
+  // it('#merge does not merge a changeset with different content', () => {
+  //   let dummyChangesetA = Changeset(dummyModel, userSchema));
+  //   let dummyChangesetB = Changeset({}, lookupValidator(dummyValidations));
+
+  //   expect(() => dummyChangesetA.merge(dummyChangesetB)).toThrow();
+  // });
+
+  // it('#merge preserves content and validator of origin changeset', async () => {
+  //   delete dummyModel.save;
+  //   let dummyChangesetA = Changeset(dummyModel, userSchema));
+  //   let dummyChangesetB = Changeset(dummyModel, userSchema);
+  //   let dummyChangesetC = dummyChangesetA.merge(dummyChangesetB);
+  //   let expectedErrors = [{ key: 'name', validation: 'too short', value: 'a' }];
+
+  //   dummyChangesetC.set('name', 'a');
+  //   expect(dummyChangesetC.get('errors')).toEqual(expectedErrors);
+
+  //   dummyChangesetC.set('name', 'Jim Bob');
+  //   await dummyChangesetC.save();
+
+  //   expect(dummyModel.name).toBe('Jim Bob');
+  // });
+
+  // /**
+  //  * #rollback
+  //  */
+
+  // it('#rollback restores old values', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedChanges = [
+  //     { key: 'firstName', value: 'foo' },
+  //     { key: 'lastName', value: 'bar' },
+  //     { key: 'name', value: '' }
+  //   ];
+  //   let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
+  //   dummyChangeset.set('firstName', 'foo');
+  //   dummyChangeset.set('lastName', 'bar');
+  //   dummyChangeset.set('name', '');
+
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.errors).toEqual(expectedErrors);
+  //   expect(dummyChangeset.isDirty).toBe(true);
+  //   dummyChangeset.rollback();
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(dummyChangeset.errors).toEqual([]);
+  //   expect(dummyChangeset.isDirty).toBe(false);
+  // });
+
+  // it('#rollback resets valid state', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('name', 'a');
+
+  //   expect(dummyChangeset.isInvalid).toBeTruthy();
+  //   expect(dummyChangeset.isDirty).toBe(true);
+  //   dummyChangeset.rollback();
+  //   expect(dummyChangeset.isValid).toBeTruthy();
+  //   expect(dummyChangeset.isDirty).toBe(false);
+  // });
+
+  // it('#rollback twice works', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('name', 'abcde');
+
+  //   let expectedChanges = [{ key: 'name', value: 'abcde' }];
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   dummyChangeset.rollback();
+  //   expect(dummyChangeset.changes).toEqual([]);
+
+  //   dummyChangeset.set('name', 'mnop');
+  //   expectedChanges = [{ key: 'name', value: 'mnop' }];
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.isDirty).toBe(true);
+  //   dummyChangeset.rollback();
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(dummyChangeset.isDirty).toBe(false);
+  // });
+
+  // it('#rollback twice with nested keys works', () => {
+  //   dummyModel['org'] = {
+  //     asia: { sg: null }
+  //   };
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('org.asia.sg', 'sg');
+
+  //   let expectedChanges = [{ key: 'org.asia.sg', value: 'sg' }];
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   dummyChangeset.rollback();
+  //   expect(dummyChangeset.changes).toEqual([]);
+
+  //   dummyChangeset.set('org.asia.sg', 'Singapore');
+  //   expectedChanges = [{ key: 'org.asia.sg', value: 'Singapore' }];
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   dummyChangeset.rollback();
+  //   expect(dummyChangeset.changes).toEqual([]);
+  // });
+
+  // it('#rollbackInvalid clears errors and keeps valid values', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedChanges = [
+  //     { key: 'firstName', value: 'foo' },
+  //     { key: 'lastName', value: 'bar' },
+  //     { key: 'name', value: '' }
+  //   ];
+  //   let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
+  //   dummyChangeset.set('firstName', 'foo');
+  //   dummyChangeset.set('lastName', 'bar');
+  //   dummyChangeset.set('name', '');
+
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.errors).toEqual(expectedErrors);
+  //   dummyChangeset.rollbackInvalid();
+  //   expectedChanges = [
+  //     { key: 'firstName', value: 'foo' },
+  //     { key: 'lastName', value: 'bar' }
+  //   ];
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.errors).toEqual([]);
+  // });
+
+  // it('#rollbackInvalid a specific key clears key error and keeps valid values', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedChanges = [
+  //     { key: 'firstName', value: 'foo' },
+  //     { key: 'lastName', value: 'bar' },
+  //     { key: 'password', value: false },
+  //     { key: 'name', value: '' }
+  //   ];
+  //   let expectedErrors = [
+  //     { key: 'password', validation: ['foo', 'bar'], value: false },
+  //     { key: 'name', validation: 'too short', value: '' }
+  //   ];
+  //   dummyChangeset.set('firstName', 'foo');
+  //   dummyChangeset.set('lastName', 'bar');
+  //   dummyChangeset.set('password', false);
+  //   dummyChangeset.set('name', '');
+
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.errors).toEqual(expectedErrors);
+  //   dummyChangeset.rollbackInvalid('name');
+  //   expectedChanges = [
+  //     { key: 'firstName', value: 'foo' },
+  //     { key: 'lastName', value: 'bar' },
+  //     { key: 'password', value: false }
+  //   ];
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expectedErrors = [{ key: 'password', validation: ['foo', 'bar'], value: false }];
+  //   expect(dummyChangeset.errors).toEqual(expectedErrors);
+  // });
+
+  // it('#rollbackInvalid resets valid state', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('name', 'a');
+
+  //   expect(dummyChangeset.isInvalid).toBeTruthy();
+  //   dummyChangeset.rollbackInvalid();
+  //   expect(dummyChangeset.isValid).toBeTruthy();
+  // });
+
+  // it('#rollbackInvalid will not remove changes that are valid', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('name', 'abcd');
+
+  //   let expectedChanges = [{ key: 'name', value: 'abcd' }];
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.isValid).toBeTruthy();
+  //   dummyChangeset.rollbackInvalid('name');
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.isValid).toBeTruthy();
+  // });
+
+  // it('#rollbackInvalid works for keys not on changeset', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedChanges = [
+  //     { key: 'firstName', value: 'foo' },
+  //     { key: 'lastName', value: 'bar' },
+  //     { key: 'name', value: '' }
+  //   ];
+  //   let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
+  //   dummyChangeset.set('firstName', 'foo');
+  //   dummyChangeset.set('lastName', 'bar');
+  //   dummyChangeset.set('name', '');
+
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.errors).toEqual(expectedErrors);
+  //   dummyChangeset.rollbackInvalid('dowat?');
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.errors).toEqual(expectedErrors);
+  // });
+
+  // it('#rollbackProperty restores old value for specified property only', () => {
+  //   dummyModel.firstName = 'Jim';
+  //   dummyModel.lastName = 'Bob';
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedChanges = [{ key: 'lastName', value: 'bar' }];
+  //   dummyChangeset.set('firstName', 'foo');
+  //   dummyChangeset.set('lastName', 'bar');
+
+  //   dummyChangeset.rollbackProperty('firstName');
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  // });
+
+  // it('#rollbackProperty clears errors for specified property', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let expectedChanges = [
+  //     { key: 'firstName', value: 'foo' },
+  //     { key: 'lastName', value: 'bar' },
+  //     { key: 'name', value: '' }
+  //   ];
+  //   let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
+  //   dummyChangeset.set('firstName', 'foo');
+  //   dummyChangeset.set('lastName', 'bar');
+  //   dummyChangeset.set('name', '');
+
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.errors).toEqual(expectedErrors);
+  //   dummyChangeset.rollbackProperty('name');
+  //   expectedChanges = [
+  //     { key: 'firstName', value: 'foo' },
+  //     { key: 'lastName', value: 'bar' }
+  //   ];
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.errors).toEqual([]);
+  // });
+
+  // it('#rollbackProperty resets valid state', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+
+  //   expect(dummyChangeset.isInvalid).toEqual(false);
+  //   expect(dummyChangeset.isValid).toEqual(true);
+
+  //   dummyChangeset.set('name', 'a');
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+
+  //   dummyChangeset.rollbackProperty('name');
+
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  // });
+
+  // it('can update nested keys after rollback changes.', () => {
+  //   let expectedResult: any = {
+  //     org: {
+  //       asia: { sg: 'sg' },
+  //       usa: {
+  //         ny: 'ny',
+  //         ma: { name: 'Massachusetts' }
+  //       }
+  //     }
+  //   };
+  //   dummyModel['org'] = {
+  //     asia: { sg: null },
+  //     usa: {
+  //       ny: null,
+  //       ma: { name: null }
+  //     }
+  //   };
+
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('org.asia.sg', 'sg');
+  //   dummyChangeset.set('org.usa.ny', 'ny');
+  //   dummyChangeset.set('org.usa.ma', { name: 'Massachusetts' });
+  //   dummyChangeset.execute();
+  //   expect(dummyModel.org).toEqual(expectedResult.org);
+
+  //   expectedResult.org.usa.or = 'or';
+  //   dummyChangeset.rollback();
+  //   dummyChangeset.set('org.usa.or', 'or');
+  //   dummyChangeset.execute();
+  //   expect(dummyModel.org).toEqual(expectedResult.org);
+  // });
+
+  /**
+   * #validate
+   */
+
+  // it.only('#validate/0 validates all fields immediately', async () => {
+  //   dummyModel.name = 'J';
+  //   dummyModel.age = 10;
+  //   dummyModel.password = false;
+  //   dummyModel.options = null;
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+
+  //   await dummyChangeset.validate();
+  //   expect(get(dummyChangeset, 'error.password')).toEqual({
+  //     validation: ['foo', 'bar'],
+  //     value: false
+  //   });
+  //   expect(dummyChangeset.changes).toEqual({});
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(8);
+  // });
+
+  // it('#validate/0 validates nested fields', async () => {
+  //   dummyModel.org = { usa: { ny: 7 } };
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   await dummyChangeset.validate();
+  //   expect(get(dummyChangeset, 'error.org.usa.ny')).toEqual({
+  //     validation: ['only letters work'],
+  //     value: 7
+  //   });
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(8);
+  // });
+
+  // it('#validate/1 validates a single field immediately', async () => {
+  //   dummyModel.name = 'J';
+  //   dummyModel.password = '123';
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   await dummyChangeset.validate('name');
+  //   expect(get(dummyChangeset, 'error.name')).toEqual({ validation: 'too short', value: 'J' });
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(1);
+  // });
+
+  // it('#validate/1 validates with an falsey string value for the validator message', async () => {
+  //   dummyModel.age = 120;
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   await dummyChangeset.validate('age');
+  //   expect(get(dummyChangeset, 'error.age')).toEqual({ validation: '', value: 120 });
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(1);
+  // });
+
+  // it('#validate validates a multiple field immediately', async () => {
+  //   dummyModel.name = 'J';
+  //   dummyModel.password = false;
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   await dummyChangeset.validate('name', 'password');
+  //   expect(get(dummyChangeset, 'error.name')).toEqual({ validation: 'too short', value: 'J' });
+  //   expect(get(dummyChangeset, 'error.password')).toEqual({
+  //     validation: ['foo', 'bar'],
+  //     value: false
+  //   });
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(2);
+  // });
+
+  // it('#validate/1 validates a property with no validation', async () => {
+  //   dummyModel.org = {};
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   await dummyChangeset.validate('org');
+  //   expect(get(dummyChangeset, 'error.org')).toEqual(undefined);
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(0);
+  // });
+
+  // it('#validate works correctly with changeset values', async () => {
+  //   dummyModel = {
+  //     ...dummyModel,
+  //     ...{
+  //       name: undefined,
+  //       email: undefined,
+  //       password: false,
+  //       async: true,
+  //       passwordConfirmation: false,
+  //       options: {},
+  //       org: {
+  //         isCompliant: undefined,
+  //         usa: {
+  //           ny: undefined
+  //         }
+  //       },
+  //       size: {
+  //         value: undefined,
+  //         power10: 10
+  //       }
+  //     }
+  //   };
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(0);
+
+  //   dummyChangeset.set('name', 'Jim Bob');
+
+  //   await dummyChangeset.validate();
+
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(5);
+  //   expect(get(dummyChangeset, 'errors')[0].key).toBe('password');
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+
+  //   dummyChangeset.set('passwordConfirmation', true);
+
+  //   await dummyChangeset.validate();
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(5);
+  //   expect(get(dummyChangeset, 'errors')[0].key).toBe('org.usa.ny');
+  //   expect(get(dummyChangeset, 'errors')[1].key).toBe('org.isCompliant');
+  //   expect(get(dummyChangeset, 'errors')[2].key).toBe('password');
+  //   expect(get(dummyChangeset, 'errors')[3].key).toBe('passwordConfirmation');
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+
+  //   dummyChangeset.set('org.isCompliant', true);
+  //   dummyChangeset.set('password', 'foobar');
+  //   dummyChangeset.set('passwordConfirmation', 'foobar');
+  //   dummyChangeset.set('email', 'scott.mail@gmail.com');
+  //   dummyChangeset.set('org.usa.ny', 'NY');
+  //   dummyChangeset.set('size.value', 1001);
+
+  //   await dummyChangeset.validate();
+
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(0);
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect((dummyChangeset.size as Record<string, any>).value).toEqual(1001);
+  //   expect((dummyChangeset.size as Record<string, any>).power10).toEqual(10);
+  // });
+
+  // it('#validate works correctly with complex values', () => {
+  //   dummyModel = {};
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   dummyChangeset.set('options', { persist: true });
+  //   dummyChangeset.validate();
+  //   expect(dummyChangeset.changes[0]).toEqual({ key: 'options', value: { persist: true } });
+  // });
+
+  // it('#validate marks actual valid changes', async () => {
+  //   dummyModel = {
+  //     ...dummyModel,
+  //     ...{ name: 'Jim Bob', password: true, passwordConfirmation: true, async: true }
+  //   };
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   dummyChangeset.set('name', 'foo bar');
+  //   dummyChangeset.set('password', false);
+
+  //   await dummyChangeset.validate();
+  //   expect(dummyChangeset.changes).toEqual([
+  //     { key: 'name', value: 'foo bar' },
+  //     { key: 'password', value: false }
+  //   ]);
+  // });
+
+  // it('#validate does not mark changes when nothing has changed', async () => {
+  //   let options = {
+  //     persist: true,
+  //     // test isEqual to ensure we're using Ember.isEqual for comparison
+  //     isEqual(other: Record<string, any>) {
+  //       return this.persist === other.persist;
+  //     }
+  //   };
+  //   dummyModel = {
+  //     ...dummyModel,
+  //     ...{
+  //       name: 'Jim Bob',
+  //       email: 'jimmy@bob.com',
+  //       password: true,
+  //       passwordConfirmation: true,
+  //       async: true,
+  //       options,
+  //       org: {
+  //         isCompliant: true,
+  //         usa: {
+  //           ny: 'NY'
+  //         }
+  //       },
+  //       size: {
+  //         value: 1001,
+  //         power10: 10
+  //       }
+  //     }
+  //   };
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   dummyChangeset.set('options', options);
+
+  //   await dummyChangeset.validate();
+  //   expect(dummyChangeset.error).toEqual({});
+  //   expect(dummyChangeset.changes).toEqual([]);
+  // });
+
+  // it('#validate/nested validates nested fields immediately', async () => {
+  //   dummyModel['org'] = {
+  //     usa: {
+  //       ny: null
+  //     }
+  //   };
+
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   await dummyChangeset.validate('org.usa.ny');
+  //   expect(get(dummyChangeset, 'error.org.usa.ny')).toEqual({
+  //     validation: ['must be present'],
+  //     value: null
+  //   });
+  //   /* expect(dummyChangeset.changes).toEqual([]); */
+  //   /* expect(dummyChangeset.errors.length).toBe(1); */
+  // });
+
+  // it('#validate marks actual valid changes', async () => {
+  //   dummyModel = {
+  //     ...dummyModel,
+  //     ...{ name: 'Jim Bob', password: true, passwordConfirmation: true }
+  //   };
+  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+
+  //   dummyChangeset.set('name', 'foo bar');
+  //   dummyChangeset.set('password', false);
+  //   dummyChangeset.set('async', true);
+
+  //   await dummyChangeset.validate();
+  //   expect(dummyChangeset.changes).toEqual([
+  //     { key: 'name', value: 'foo bar' },
+  //     { key: 'password', value: false },
+  //     { key: 'async', value: true }
+  //   ]);
+  // });
+
+  // it('#validate changeset getter', async () => {
+  //   class MyModel {
+  //     isOptionOne = false;
+  //     isOptionTwo = false;
+  //     isOptionThree = true;
+  //   }
+
+  //   const Validations = {
+  //     isOptionSelected: (newValue: boolean) => {
+  //       return newValue === true ? true : 'No options selected';
+  //     }
+  //   };
+
+  //   function myValidator({
+  //     key,
+  //     newValue,
+  //     oldValue,
+  //     changes,
+  //     content
+  //   }: {
+  //     key: string;
+  //     newValue: unknown;
+  //     oldValue: unknown;
+  //     changes: any;
+  //     content: any;
+  //   }) {
+  //     let validatorFn = get(Validations, key);
+
+  //     if (typeof validatorFn === 'function') {
+  //       return validatorFn(newValue, oldValue, changes, content);
+  //     }
+  //   }
+
+  //   const myObject = new MyModel();
+  //   const myChangeset = Changeset(myObject, myValidator, Validations);
+
+  //   Object.defineProperty(myChangeset, 'isOptionSelected', {
+  //     get() {
+  //       return this.get('isOptionOne') || this.get('isOptionTwo') || this.get('isOptionThree');
+  //     }
+  //   });
+
+  //   await myChangeset.validate();
+  //   expect(myChangeset.isInvalid).toEqual(false);
+
+  //   myChangeset.set('isOptionThree', false);
+  //   await myChangeset.validate();
+  //   expect(myChangeset.isInvalid).toEqual(true);
+
+  //   myChangeset.set('isOptionTwo', true);
+  //   await myChangeset.validate();
+  //   expect(myChangeset.isInvalid).toEqual(false);
+  // });
+
+  // it('#validate/0 works with a class', async () => {
+  //   class PersonalValidator {
+  //     _validate() {
+  //       return 'oh no';
+  //     }
+  //     async validate(_key: string, _newValue: unknown) {
+  //       return this._validate();
+  //     }
+  //   }
+  //   const validationMap = {
+  //     name: new PersonalValidator()
+  //   };
+  //   dummyModel.name = 'J';
+  //   let dummyChangeset = Changeset(dummyModel, lookupValidator(validationMap), validationMap);
+  //   dummyChangeset.name = null;
+
+  //   await dummyChangeset.validate();
+
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(1);
+  //   expect(get(dummyChangeset, 'error.name.validation')).toEqual('oh no');
+  //   expect(dummyChangeset.changes).toEqual([
+  //     {
+  //       key: 'name',
+  //       value: null
+  //     }
+  //   ]);
+  // });
+
+  // it('#validate/0 works with a class and multiple validators', async () => {
+  //   function validatePresence(): Function {
+  //     return (val: unknown) => !!val;
+  //   }
+  //   class PersonalValidator {
+  //     _validate() {
+  //       return 'oh no';
+  //     }
+  //     async validate(_key: string, _newValue: unknown) {
+  //       return this._validate();
+  //     }
+  //   }
+  //   const validationMap = {
+  //     name: [validatePresence(), new PersonalValidator()]
+  //   };
+  //   dummyModel.name = 'J';
+  //   let dummyChangeset = Changeset(dummyModel, lookupValidator(validationMap), validationMap);
+  //   dummyChangeset.name = null;
+
+  //   await dummyChangeset.validate();
+
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(1);
+  //   expect(get(dummyChangeset, 'error.name.validation')).toEqual(['oh no']);
+  //   expect(dummyChangeset.changes).toEqual([
+  //     {
+  //       key: 'name',
+  //       value: null
+  //     }
+  //   ]);
+  // });
+
+  // it('#isInvalid does not trigger validations without validate keys', async () => {
+  //   const model = { name: 'o' };
+  //   const dummyChangeset = Changeset(model, lookupValidator(dummyValidations));
+
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect(dummyChangeset.isInvalid).toEqual(false);
+
+  //   await dummyChangeset.validate();
+
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect(dummyChangeset.isInvalid).toEqual(false);
+  // });
+
+  // it('#isInvalid does not trigger on init of changeset', async () => {
+  //   const model = { name: 'o' };
+  //   const dummyChangeset = Changeset(model, lookupValidator(dummyValidations));
+
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect(dummyChangeset.isInvalid).toEqual(false);
+
+  //   await dummyChangeset.validate('name');
+
+  //   expect(dummyChangeset.isValid).toEqual(false);
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  // });
+
+  // /**
+  //  * #addError
+  //  */
+
+  // it('#addError adds an error to the changeset', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.addError('email', {
+  //     value: 'jim@bob.com',
+  //     validation: 'Email already taken'
+  //   });
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   expect(get(dummyChangeset, 'error.email.validation')).toBe('Email already taken');
+  //   dummyChangeset.set('email', 'unique@email.com');
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  // });
+
+  // it('#addError adds an error then validates', async () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.addError('email', {
+  //     value: 'jim@bob.com',
+  //     validation: 'Email already taken'
+  //   });
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   await dummyChangeset.validate();
+
+  //   expect(get(dummyChangeset, 'error.email')).toEqual({
+  //     validation: 'Email already taken',
+  //     value: 'jim@bob.com'
+  //   });
+  //   expect(dummyChangeset.changes).toEqual([]);
+  //   expect(get(dummyChangeset, 'errors.length')).toBe(1);
+  // });
+
+  // it('#addError adds an error to the changeset using the shortcut', function() {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('email', 'jim@bob.com');
+  //   dummyChangeset.addError('email', 'Email already taken');
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   expect(get(dummyChangeset, 'error.email.validation')).toBe('Email already taken');
+  //   expect(get(dummyChangeset, 'error.email.value')).toBe('jim@bob.com');
+  //   expect(dummyChangeset.changes).toEqual([{ key: 'email', value: 'jim@bob.com' }]);
+  //   dummyChangeset.set('email', 'unique@email.com');
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect(dummyChangeset.changes[0]).toEqual({ key: 'email', value: 'unique@email.com' });
+  // });
+
+  // it('#addError adds an error to the changeset on a nested property', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.addError('email.localPart', 'Cannot contain +');
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   expect(get(dummyChangeset, 'error.email.localPart.validation')).toBe('Cannot contain +');
+  //   dummyChangeset.set('email.localPart', 'ok');
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  // });
+
+  // it('#addError adds an array of errors to the changeset', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.addError('email', ['jim@bob.com', 'Email already taken']);
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   expect(get(dummyChangeset, 'error.email.validation')).toEqual([
+  //     'jim@bob.com',
+  //     'Email already taken'
+  //   ]);
+  //   dummyChangeset.set('email', 'unique@email.com');
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  // });
+
+  // /**
+  //  * #pushErrors
+  //  */
+
+  // it('#pushErrors pushes an error into an array of existing validations', function() {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.set('email', 'jim@bob.com');
+  //   dummyChangeset.addError('email', 'Email already taken');
+  //   dummyChangeset.pushErrors('email', 'Invalid email format');
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   expect(get(dummyChangeset, 'error.email.validation')).toEqual([
+  //     'Email already taken',
+  //     'Invalid email format'
+  //   ]);
+  //   expect(get(dummyChangeset, 'error.email.value')).toBe('jim@bob.com');
+  //   expect(dummyChangeset.changes).toEqual([{ key: 'email', value: 'jim@bob.com' }]);
+  //   dummyChangeset.set('email', 'unique@email.com');
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect(dummyChangeset.changes[0]).toEqual({ key: 'email', value: 'unique@email.com' });
+  // });
+
+  // it('#pushErrors pushes an error if no existing validations are present', function() {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('name', 'J');
+  //   dummyChangeset.pushErrors('name', 'cannot be J');
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   expect(dummyChangeset.isValid).toEqual(false);
+  //   expect(get(dummyChangeset, 'error.name.validation')).toEqual(['too short', 'cannot be J']);
+  //   expect(get(dummyChangeset, 'error.name.value')).toBe('J');
+  //   dummyChangeset.set('name', 'Good name');
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  //   expect(dummyChangeset.isInvalid).toEqual(false);
+  // });
+
+  // it('#pushErrors adds an error to the changeset on a nested property', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   dummyChangeset.pushErrors('email.localPart', 'Cannot contain +');
+  //   dummyChangeset.pushErrors('email.localPart', 'is too short');
+
+  //   expect(dummyChangeset.isInvalid).toEqual(true);
+  //   expect(get(dummyChangeset, 'error.email.localPart.validation')).toEqual([
+  //     'Cannot contain +',
+  //     'is too short'
+  //   ]);
+  //   dummyChangeset.set('email.localPart', 'ok');
+  //   expect(dummyChangeset.isValid).toEqual(true);
+  // });
+
+  // /**
+  //  * #snapshot
+  //  */
+
+  // it('#snapshot creates a snapshot of the changeset', () => {
+  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   dummyChangeset.set('name', 'Pokemon Go');
+  //   dummyChangeset.set('password', false);
+  //   let snapshot = dummyChangeset.snapshot();
+  //   let expectedResult = {
+  //     changes: { name: 'Pokemon Go', password: false },
+  //     errors: { password: { validation: ['foo', 'bar'], value: false } }
+  //   };
+
+  //   expect(snapshot).toEqual(expectedResult);
+  //   dummyChangeset.set('name', "Gotta catch'em all");
+  //   expect(snapshot).toEqual(expectedResult);
+  // });
+
+  // /**
+  //  * #restore
+  //  */
+
+  // it('#restore restores a snapshot of the changeset', () => {
+  //   let dummyChangesetA = Changeset(dummyModel, userSchema));
+  //   let dummyChangesetB = Changeset(dummyModel, userSchema));
+  //   dummyChangesetA.set('name', 'Pokemon Go');
+  //   dummyChangesetA.set('password', false);
+  //   let snapshot = dummyChangesetA.snapshot();
+
+  //   expect(dummyChangesetB.isValid).toEqual(true);
+  //   dummyChangesetB.restore(snapshot);
+  //   expect(dummyChangesetB.isInvalid).toEqual(true);
+  //   expect(get(dummyChangesetB, 'change.name')).toBe('Pokemon Go');
+  //   expect(get(dummyChangesetB, 'error.password')).toEqual({
+  //     validation: ['foo', 'bar'],
+  //     value: false
+  //   });
+  // });
+
+  // it('#restore restores a snapshot of the changeset with nested values', () => {
+  //   let user = { name: 'Adam', address: { country: 'United States' } };
+  //   let changeset = Changeset(user);
+
+  //   changeset.set('name', 'Jim Bob');
+  //   changeset.set('address.country', 'North Korea');
+  //   let snapshot1 = changeset.snapshot();
+
+  //   changeset.set('name', 'Poteto');
+  //   changeset.set('address.country', 'Australia');
+
+  //   changeset.restore(snapshot1);
+
+  //   expect(changeset.get('name')).toBe('Jim Bob');
+  //   expect(changeset.get('address.country')).toBe('North Korea');
+  //   expect(changeset.changes).toEqual([
+  //     { key: 'name', value: 'Jim Bob' },
+  //     { key: 'address.country', value: 'North Korea' }
+  //   ]);
+  // });
+
+  // /**
+  //  * #cast
+  //  */
+
+  // it('#cast allows only specified keys to exist on the changeset', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const expectedResult = [
+  //     { key: 'name', value: 'Pokemon Go' },
+  //     { key: 'password', value: true }
+  //   ];
+  //   const allowed = ['name', 'password'];
+  //   dummyChangeset.set('name', 'Pokemon Go');
+  //   dummyChangeset.set('password', true);
+  //   dummyChangeset.set('unwantedProp', 123);
+  //   dummyChangeset.cast(allowed);
+
+  //   expect(dummyChangeset.get('changes')).toEqual(expectedResult);
+  //   expect(dummyChangeset.get('unwantedProp')).toBe(undefined);
+  // });
+
+  // it('#cast noops if no keys are passed', () => {
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const expectedResult = [
+  //     { key: 'name', value: 'Pokemon Go' },
+  //     { key: 'password', value: true },
+  //     { key: 'unwantedProp', value: 123 }
+  //   ];
+  //   dummyChangeset.set('name', 'Pokemon Go');
+  //   dummyChangeset.set('password', true);
+  //   dummyChangeset.set('unwantedProp', 123);
+  //   dummyChangeset.cast();
+
+  //   expect(dummyChangeset.get('changes')).toEqual(expectedResult);
+  // });
+
+  // /**
+  //  * #isValidating
+  //  */
+
+  // it('isValidating returns true when validations have not resolved', () => {
+  //   let dummyChangeset;
+  //   const _validator = () => Promise.resolve([]);
+  //   const _validations = {
+  //     reservations() {
+  //       return _validator();
+  //     }
+  //   };
+
+  //   dummyModel['reservations'] = 'ABC12345';
+  //   dummyChangeset = Changeset(dummyModel, _validator, _validations);
+  //   dummyChangeset['reservations'] = 'DCE12345';
+
+  //   dummyChangeset.validate();
+  //   // expect(dummyChangeset.change, { reservations: 'DCE12345' });
+
+  //   expect(dummyChangeset.isValidating()).toBeTruthy();
+  //   expect(dummyChangeset.isValidating('reservations')).toBeTruthy();
+  // });
+
+  // it('isValidating returns false when validations have resolved', () => {
+  //   let dummyChangeset;
+  //   const _validator = () => Promise.resolve(true);
+  //   const _validations = {
+  //     reservations() {
+  //       return _validator();
+  //     }
+  //   };
+
+  //   dummyModel['reservations'] = 'ABC12345';
+  //   dummyChangeset = Changeset(dummyModel, _validator, _validations);
+
+  //   dummyChangeset.validate();
+  //   expect(dummyChangeset.isValidating()).toBeTruthy();
+  //   expect(dummyChangeset.isValidating('reservations')).toBeTruthy();
+  // });
+
+  // /**
+  //  * beforeValidation
+  //  */
+
+  // it('beforeValidation event is fired before validation', () => {
+  //   let dummyChangeset;
+  //   const _validator = () => Promise.resolve([]);
+  //   const _validations = {
+  //     reservations() {
+  //       return _validator();
+  //     }
+  //   };
+  //   let hasFired = false;
+
+  //   dummyModel['reservations'] = 'ABC12345';
+  //   dummyChangeset = Changeset(dummyModel, _validator, _validations);
+  //   dummyChangeset.on('beforeValidation', () => {
+  //     hasFired = true;
+  //   });
+
+  //   dummyChangeset.validate();
+  //   expect(hasFired).toBeTruthy();
+  // });
+
+  // it('beforeValidation event is triggered with the key', () => {
+  //   let dummyChangeset;
+  //   const _validator = () => Promise.resolve('');
+  //   const _validations = {
+  //     reservations() {
+  //       return _validator();
+  //     }
+  //   };
+  //   let hasFired = false;
+
+  //   dummyModel['reservations'] = 'ABC12345';
+  //   dummyChangeset = Changeset(dummyModel, _validator, _validations);
+  //   dummyChangeset.on('beforeValidation', (key: string) => {
+  //     if (key === 'reservations') {
+  //       hasFired = true;
+  //     }
+  //   });
+
+  //   dummyChangeset.validate();
+  //   expect(hasFired).toBeTruthy();
+  // });
+
+  // /**
+  //  * afterValidation
+  //  */
+
+  // it('afterValidation event is fired after validation', async () => {
+  //   let dummyChangeset;
+  //   const _validator = () => Promise.resolve(true);
+  //   const _validations = {
+  //     reservations() {
+  //       return _validator();
+  //     }
+  //   };
+  //   let hasFired = false;
+
+  //   dummyModel['reservations'] = 'ABC12345';
+  //   dummyChangeset = Changeset(dummyModel, _validator, _validations);
+  //   dummyChangeset.on('afterValidation', () => {
+  //     hasFired = true;
+  //   });
+
+  //   await dummyChangeset.validate();
+  //   expect(hasFired).toBeTruthy();
+  // });
+
+  // it('afterValidation event is triggered with the key', async () => {
+  //   let dummyChangeset;
+  //   const _validator = () => Promise.resolve(true);
+  //   const _validations = {
+  //     reservations() {
+  //       return _validator();
+  //     }
+  //   };
+  //   let hasFired = false;
+
+  //   dummyModel['reservations'] = 'ABC12345';
+  //   dummyChangeset = Changeset(dummyModel, _validator, _validations);
+  //   dummyChangeset.on('afterValidation', (key: string) => {
+  //     if (key === 'reservations') {
+  //       hasFired = true;
+  //     }
+  //   });
+
+  //   await dummyChangeset.validate();
+  //   expect(hasFired).toBeTruthy();
+  // });
+
+  // /**
+  //  * afterRollback
+  //  */
+
+  // it('afterRollback event is fired after rollback', async () => {
+  //   let dummyChangeset;
+  //   const _validator = () => Promise.resolve(true);
+  //   const _validations = {
+  //     reservations() {
+  //       return _validator();
+  //     }
+  //   };
+  //   let hasFired = false;
+
+  //   dummyModel['reservations'] = 'ABC12345';
+  //   dummyChangeset = Changeset(dummyModel, _validator, _validations);
+  //   dummyChangeset.on('afterRollback', () => {
+  //     hasFired = true;
+  //   });
+
+  //   await dummyChangeset.rollback();
+  //   expect(hasFired).toBeTruthy();
+  // });
+
+  // /**
+  //  * Behavior.
+  //  */
+
+  // it('can set nested keys after validate', async function(done) {
+  //   expect.assertions(0);
+
+  //   dummyModel.org = {
+  //     usa: { ny: null }
+  //   };
+
+  //   const c = Changeset(dummyModel, userSchema), dummyValidations);
+  //   c.validate('org.usa.ny')
+  //     .then(() => c.set('org.usa.ny', 'should not fail'))
+  //     .finally(done());
+  // });
+
+  // async function delay(duration: number) {
+  //   return new Promise(function(resolve: Function) {
+  //     setTimeout(resolve, duration);
+  //   });
+  // }
+
+  // it('it works with out of order async validations', async () => {
+  //   let latestDelayedAsyncResolver: Function = () => {};
+
+  //   dummyValidations.delayedAsync = () => {
+  //     return new Promise(resolve => {
+  //       latestDelayedAsyncResolver = resolve;
+  //     });
+  //   };
+
+  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+
+  //   dummyChangeset.set('delayedAsync', 'first');
+  //   let firstResolver = latestDelayedAsyncResolver;
+  //   dummyChangeset.set('delayedAsync', 'second');
+  //   let secondResolver = latestDelayedAsyncResolver;
+
+  //   // second one resolves first with false
+  //   secondResolver(false);
+  //   // then the first resolves first with true
+  //   firstResolver(true);
+
+  //   // allow promises to run
+  //   await delay(1);
+
+  //   // clean up before running expectations
+  //   delete dummyValidations.delayedAsync;
+
+  //   // current value state should be "second"
+  //   // current error state should be invalid
+  //   const expectedChanges = [{ key: 'delayedAsync', value: 'second' }];
+  //   const expectedError = { delayedAsync: { validation: false, value: 'second' } };
+  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
+  //   expect(dummyChangeset.error).toEqual(expectedError);
+  // });
+
+  // /**
+  //  * #unexecute
+  //  */
+  // it('#unexecute after #save on new ember-data model', async () => {
+  //   const changeset = Changeset(dummyModel, userSchema);
+  //   try {
+  //     changeset.unexecute();
+  //     expect(true);
+  //   } catch {
+  //     expect(false);
+  //   }
+  // });
+});

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -1673,12 +1673,11 @@ describe('Unit | Utility | validation changeset', () => {
     dummyChangeset.set('name', 'Jim Bob');
     try {
       await dummyChangeset.validate();
-    } catch (e) {
-      throw Error('error');
-    } finally {
-      dummyChangeset.removeError('name');
+      dummyChangeset.removeErrors();
       expect(dummyChangeset.isValid).toEqual(true);
       expect(dummyChangeset.isInvalid).toEqual(false);
+    } catch (e) {
+      throw Error('error not supposed to be here');
     }
   });
 

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -22,14 +22,6 @@ let userSchema = object({
   createdOn: date().default(() => new Date())
 });
 
-let dogSchema = object({
-  name: string().required(),
-  age: number()
-    .required()
-    .positive()
-    .integer()
-});
-
 let dummyModel: any = {};
 const exampleArray: Array<any> = [];
 
@@ -45,7 +37,7 @@ describe('Unit | Utility | validation changeset', () => {
     expect.assertions(1);
 
     const emptyObject = {};
-    const dummyChangeset = Changeset(emptyObject, userSchema);
+    const dummyChangeset = Changeset(emptyObject);
 
     expect(dummyChangeset.toString()).toEqual('changeset:[object Object]');
   });
@@ -55,7 +47,7 @@ describe('Unit | Utility | validation changeset', () => {
    */
 
   it('#change returns the changes object', () => {
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     const expectedResult = { name: 'a' };
     dummyChangeset.set('name', 'a');
 
@@ -64,7 +56,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#change supports `undefined`', () => {
     const model = { name: 'a' };
-    const dummyChangeset = Changeset(model, userSchema);
+    const dummyChangeset = Changeset(model);
     const expectedResult = { name: undefined };
     dummyChangeset.set('name', undefined);
 
@@ -72,7 +64,7 @@ describe('Unit | Utility | validation changeset', () => {
   });
 
   it('#change works with arrays', () => {
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     const newArray = [...exampleArray, 'new'];
     const expectedResult = { teams: newArray };
     dummyChangeset.set('teams', newArray);
@@ -84,7 +76,7 @@ describe('Unit | Utility | validation changeset', () => {
   //  * #errors
   //  */
   // it('#errors returns the error object and keeps changes', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
   //   let expectedResult = [{ key: 'name', validation: 'too short', value: 'a' }];
   //   dummyChangeset.set('name', 'a');
 
@@ -93,7 +85,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('can get nested values in the errors object', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('unknown', 'wat');
   //   dummyChangeset.set('org.usa.ny', '');
   //   dummyChangeset.set('name', '');
@@ -121,7 +113,7 @@ describe('Unit | Utility | validation changeset', () => {
    */
 
   it('data reads the changeset CONTENT', () => {
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
 
     expect(dummyChangeset.data).toEqual(dummyModel);
   });
@@ -130,7 +122,7 @@ describe('Unit | Utility | validation changeset', () => {
    * #isValid
    */
   it('does not validate with default options', () => {
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
 
     expect(dummyChangeset.get('isValid')).toBeTruthy();
   });
@@ -147,7 +139,7 @@ describe('Unit | Utility | validation changeset', () => {
     dummyModel.name = 'Bobby';
     dummyModel.thing = 123;
     dummyModel.nothing = null;
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'Bobby');
     dummyChangeset.set('nothing', null);
 
@@ -156,7 +148,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it("isPristine returns false if changes are not equal to content's values", () => {
     dummyModel.name = 'Bobby';
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'Bobby');
     dummyChangeset.set('thing', 123);
 
@@ -166,7 +158,7 @@ describe('Unit | Utility | validation changeset', () => {
   it('isPristine works with `null` values', () => {
     dummyModel.name = null;
     dummyModel.age = 15;
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
 
     expect(dummyChangeset.get('isPristine')).toBeTruthy();
 
@@ -182,14 +174,14 @@ describe('Unit | Utility | validation changeset', () => {
    */
 
   it('#set dirties changeset', () => {
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'foo');
 
     expect(dummyChangeset.isDirty).toBe(true);
   });
 
   it('#isDirty after set', () => {
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'foo');
 
     expect(dummyChangeset.isDirty).toBe(true);
@@ -197,7 +189,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#isDirty reset after execute', () => {
     dummyModel.name = {};
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = {
       short: 'foo'
     };
@@ -211,7 +203,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#isDirty reset after rollback', () => {
     dummyModel.name = {};
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = {
       short: 'foo'
     };
@@ -225,7 +217,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#isDirty is false when no set', () => {
     dummyModel['name'] = { nick: 'bar' };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.name;
 
     expect(dummyChangeset.isDirty).toBe(false);
@@ -233,7 +225,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#isDirty is false when no set with deep values', () => {
     dummyModel['details'] = { name: { nick: 'bar' } };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.get('details.name');
 
     expect(dummyChangeset.isDirty).toBe(false);
@@ -248,7 +240,7 @@ describe('Unit | Utility | validation changeset', () => {
       }
     }
     dummyModel['details'] = { name: {} };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.get('details.name');
     const dogKlass = new Dog({ nickname: 'bar' });
     dummyChangeset['details'] = { name: dogKlass };
@@ -259,7 +251,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set does not dirty changeset with same date', () => {
     dummyModel.createTime = new Date('2013-05-01');
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('createTime', new Date('2013-05-01'));
 
     expect(dummyChangeset.isDirty).toBe(false);
@@ -271,7 +263,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#get proxies to content', () => {
     dummyModel.name = 'Jim Bob';
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     const result = dummyChangeset.name;
 
     expect(result).toBe('Jim Bob');
@@ -282,7 +274,7 @@ describe('Unit | Utility | validation changeset', () => {
       name?: string;
     }
     Dog.prototype.name = 'Jim Bob';
-    const dummyChangeset = Changeset(new Dog(), userSchema);
+    const dummyChangeset = Changeset(new Dog());
     const result = dummyChangeset.name;
 
     expect(result).toBe('Jim Bob');
@@ -298,12 +290,9 @@ describe('Unit | Utility | validation changeset', () => {
 
     const d = new Date('2015');
     const momentInstance = new Moment(d);
-    const c = Changeset(
-      {
-        startDate: momentInstance
-      },
-      userSchema
-    );
+    const c = Changeset({
+      startDate: momentInstance
+    });
 
     const newValue = c.get('startDate');
     expect(newValue.date).toEqual(momentInstance.date);
@@ -324,12 +313,9 @@ describe('Unit | Utility | validation changeset', () => {
     const d = new Date('2015');
     const momentInstance = new Moment(d);
     momentInstance._isUTC = true;
-    const c = Changeset(
-      {
-        startDate: momentInstance
-      },
-      userSchema
-    );
+    const c = Changeset({
+      startDate: momentInstance
+    });
 
     let newValue = c.get('startDate');
     expect(newValue.date).toEqual(momentInstance.date);
@@ -362,12 +348,9 @@ describe('Unit | Utility | validation changeset', () => {
     const d = new Date('2015');
     const momentInstance = new Moment(d);
     momentInstance._isUTC = true;
-    const c = Changeset(
-      {
-        startDate: momentInstance
-      },
-      userSchema
-    );
+    const c = Changeset({
+      startDate: momentInstance
+    });
 
     let newValue = c.get('startDate');
     expect(newValue.date).toEqual(momentInstance.date);
@@ -387,7 +370,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#get returns change if present', () => {
     dummyModel.name = 'Jim Bob';
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = 'Milton Waddams';
     const result = dummyChangeset.name;
 
@@ -396,7 +379,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#get returns change that is a blank value', () => {
     dummyModel.name = 'Jim Bob';
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = '';
     const result = dummyChangeset.name;
 
@@ -405,7 +388,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#get returns change that is has undefined as value', () => {
     dummyModel.name = 'Jim Bob';
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = undefined;
     const result = dummyChangeset.name;
 
@@ -420,7 +403,7 @@ describe('Unit | Utility | validation changeset', () => {
     };
 
     expect(get(dummyModel, 'contact.emails')).toEqual(['bob@email.com', 'the_bob@email.com']);
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     expect(dummyChangeset.get('name')).toBe('Bob');
     expect(dummyChangeset.get('contact.emails')).toEqual(['bob@email.com', 'the_bob@email.com']);
 
@@ -458,21 +441,21 @@ describe('Unit | Utility | validation changeset', () => {
     };
 
     {
-      const c = Changeset(model, dogSchema);
+      const c = Changeset(model);
       const actual = c.get('foo.bar.dog');
       const expectedResult = "woof i'm a shiba inu, wow";
       expect(actual.bark()).toEqual(expectedResult);
     }
 
     {
-      const c = Changeset(model, dogSchema);
+      const c = Changeset(model);
       const actual = get(c, 'foo.bar.dog');
       const expectedResult = get(model, 'foo.bar.dog');
       expect(actual).toEqual(expectedResult);
     }
 
     {
-      const c = Changeset(model, dogSchema);
+      const c = Changeset(model);
       const actual = get(c, 'foo.bar.dog');
       const expectedResult = get(model, 'foo.bar.dog');
       expect(actual).toEqual(expectedResult);
@@ -481,7 +464,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#get proxies to underlying array properties', () => {
     dummyModel.users = ['user1', 'user2'];
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
 
     expect((dummyChangeset.users as Array<string>).length).toBe(2);
   });
@@ -489,7 +472,7 @@ describe('Unit | Utility | validation changeset', () => {
   it('#get works if content is undefined for nested key', () => {
     const model: Record<string, any> = {};
 
-    const c = Changeset(model, dogSchema);
+    const c = Changeset(model);
     c.set('foo.bar.cat', {
       color: 'red'
     });
@@ -501,7 +484,7 @@ describe('Unit | Utility | validation changeset', () => {
     dummyModel.toString = function() {
       return 'mine';
     };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = undefined;
     const result = dummyChangeset.toString();
 
@@ -512,7 +495,7 @@ describe('Unit | Utility | validation changeset', () => {
     dummyModel.trigger = function(arg: any) {
       expect(arg).toEqual('mine');
     };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = undefined;
     dummyChangeset.trigger('mine');
   });
@@ -523,7 +506,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set adds a change if valid', () => {
     const expectedChanges = { name: { current: 'foo', original: undefined } };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'foo');
     const changes = dummyChangeset.changes;
 
@@ -537,7 +520,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set adds a change with plain assignment without existing values', () => {
     dummyModel['name'] = { nick: 'bar' };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     const proxy: any = dummyChangeset.name;
     proxy['nick'] = 'foo';
     expect(dummyChangeset.get('name.nick')).toEqual('foo');
@@ -549,7 +532,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set adds a change with plain assignment', () => {
     dummyModel['name'] = 'bar';
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = 'foo';
     const changes = dummyChangeset.changes;
 
@@ -563,7 +546,7 @@ describe('Unit | Utility | validation changeset', () => {
   it('#set adds a date', () => {
     const d = new Date();
     const expectedChanges = { dateOfBirth: { current: d, original: undefined } };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('dateOfBirth', d);
     const changes = dummyChangeset.changes;
 
@@ -575,7 +558,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set adds a date if already set on model', () => {
     const model = { dateOfBirth: new Date() };
-    const dummyChangeset = Changeset(model, userSchema);
+    const dummyChangeset = Changeset(model);
     const d = new Date('March 25, 1990');
     dummyChangeset.set('dateOfBirth', d);
     const changes = dummyChangeset.changes;
@@ -590,7 +573,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set Ember.set works', () => {
     const expectedChanges = { name: { current: 'foo', original: undefined } };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = 'foo';
 
     expect(dummyModel.name).toBeUndefined();
@@ -609,7 +592,7 @@ describe('Unit | Utility | validation changeset', () => {
     const expectedChanges = { name: { current: { short: 'foo' }, original: {} } };
     dummyModel.name = {};
     dummyModel.org = {};
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset['name'] = {
       short: 'foo'
     };
@@ -629,7 +612,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set overrides', () => {
     const expectedChanges = { age: { current: '90', original: '10' } };
-    let dummyChangeset = Changeset({ age: '10' }, userSchema);
+    let dummyChangeset = Changeset({ age: '10' });
     dummyChangeset.set('age', '80');
     dummyChangeset.set('age', '10');
     dummyChangeset.set('age', '90');
@@ -648,7 +631,7 @@ describe('Unit | Utility | validation changeset', () => {
     set(dummyModel, 'name', {});
     let title1 = { id: 'Mr', description: 'Mister' };
     let title2 = { id: 'Mrs', description: 'Missus' };
-    let dummyChangeset: any = Changeset(dummyModel, userSchema);
+    let dummyChangeset: any = Changeset(dummyModel);
     set(dummyChangeset, 'name.title', title1);
 
     expect(get(dummyModel, 'name.title.id')).toBeUndefined();
@@ -678,7 +661,7 @@ describe('Unit | Utility | validation changeset', () => {
     set(dummyModel, 'name', {});
     let title1 = { id: 'Mr', description: 'Mister' };
     let title2 = { id: 'Mrs', description: 'Missus' };
-    let dummyChangeset: any = Changeset(dummyModel, userSchema);
+    let dummyChangeset: any = Changeset(dummyModel);
     dummyChangeset.set('name.title', title1);
 
     expect(get(dummyModel, 'name.title.id')).toBeUndefined();
@@ -715,7 +698,7 @@ describe('Unit | Utility | validation changeset', () => {
       it('works with boolean values', () => {
         let initialData = { contact: { emails: [{}, {}] } };
 
-        const changeset = Changeset(initialData, userSchema);
+        const changeset = Changeset(initialData);
 
         changeset.set('contact.emails.2', { nested: false });
         expect(changeset.get('contact.emails.2')).toEqual({ nested: false });
@@ -730,7 +713,7 @@ describe('Unit | Utility | validation changeset', () => {
       it('nested objects cannot create arrays when we have no hints', () => {
         initialData.contact = {};
 
-        const changeset = Changeset(initialData, userSchema);
+        const changeset = Changeset(initialData);
         expect(changeset.get('contact.emails')).toEqual(undefined);
 
         changeset.set('contact.emails.0', 'fred@email.com');
@@ -739,7 +722,7 @@ describe('Unit | Utility | validation changeset', () => {
       });
 
       it('can be rolled back', () => {
-        const changeset = Changeset(initialData, userSchema);
+        const changeset = Changeset(initialData);
 
         changeset.set('contact.emails.0', 'fred@email.com');
 
@@ -758,7 +741,7 @@ describe('Unit | Utility | validation changeset', () => {
       });
 
       it('can add items to the array', () => {
-        const changeset = Changeset(initialData, userSchema);
+        const changeset = Changeset(initialData);
 
         changeset.set('contact.emails.1', 'fred@email.com');
 
@@ -793,7 +776,7 @@ describe('Unit | Utility | validation changeset', () => {
       });
 
       it('can remove items from the array', () => {
-        const changeset = Changeset(initialData, userSchema);
+        const changeset = Changeset(initialData);
 
         changeset.set('contact.emails.1', 'fred@email.com');
 
@@ -837,12 +820,9 @@ describe('Unit | Utility | validation changeset', () => {
         const fred = deepObj('fred@email.com');
         const sanHolo = deepObj('sanholo@email.com');
 
-        const changeset = Changeset(
-          {
-            contacts: [bob, fred]
-          },
-          userSchema
-        );
+        const changeset = Changeset({
+          contacts: [bob, fred]
+        });
 
         // "Delete" array element
         changeset.set('contacts.0', null);
@@ -881,7 +861,7 @@ describe('Unit | Utility | validation changeset', () => {
       xit(`negative values are not allowed`, () => {
         // This test is currently disabled because setDeep doesn't have a reference to the
         // original array and setDeep is where we'd throw on invalid key values
-        const changeset = Changeset(initialData, userSchema);
+        const changeset = Changeset(initialData);
 
         expect(changeset.get('contact.emails')).toEqual(['bob@email.com']);
 
@@ -902,7 +882,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   });
 
   //   it('can modify properties on an entry', () => {
-  //     const changeset = Changeset(initialData, userSchema);
+  //     const changeset = Changeset(initialData);
 
   //     changeset.set('emails.0.primary', 'fun@email.com');
 
@@ -912,7 +892,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   });
 
   //   it('can add properties to an entry', () => {
-  //     const changeset = Changeset(initialData, userSchema);
+  //     const changeset = Changeset(initialData);
 
   //     changeset.set('emails.0.funEmail', 'fun@email.com');
 
@@ -924,7 +904,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   });
 
   //   it('can add new properties to new entries', () => {
-  //     const changeset = Changeset(initialData, userSchema);
+  //     const changeset = Changeset(initialData);
 
   //     changeset.set('emails.1.funEmail', 'fun@email.com');
   //     changeset.set('emails.1.primary', 'primary@email.com');
@@ -942,7 +922,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   });
 
   //   it('can add a new object all at once, and edit it', () => {
-  //     const changeset = Changeset(initialData, userSchema);
+  //     const changeset = Changeset(initialData);
 
   //     changeset.set('emails.1', {
   //       funEmail: 'fun@email.com',
@@ -1089,7 +1069,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     });
 
   //     it('can modify properties on an entry', () => {
-  //       const changeset = Changeset(initialData, userSchema);
+  //       const changeset = Changeset(initialData);
 
   //       changeset.set('contact.emails.0.primary', 'fun@email.com');
 
@@ -1101,7 +1081,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     });
 
   //     it('can add properties to an entry', () => {
-  //       const changeset = Changeset(initialData, userSchema);
+  //       const changeset = Changeset(initialData);
 
   //       changeset.set('contact.emails.0.funEmail', 'fun@email.com');
 
@@ -1115,7 +1095,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     });
 
   //     it('can add new properties to new entries', () => {
-  //       const changeset = Changeset(initialData, userSchema);
+  //       const changeset = Changeset(initialData);
 
   //       changeset.set('contact.emails.1.funEmail', 'fun@email.com');
   //       changeset.set('contact.emails.1.primary', 'primary@email.com');
@@ -1133,7 +1113,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     });
 
   //     it('can add a new object all at once, and edit it', () => {
-  //       const changeset = Changeset(initialData, userSchema);
+  //       const changeset = Changeset(initialData);
 
   //       changeset.set('contact.emails.1', {
   //         funEmail: 'fun@email.com',
@@ -1203,7 +1183,7 @@ describe('Unit | Utility | validation changeset', () => {
   // it('#set works for nested when the root key is "value"', () => {
   //   dummyModel.value = {};
   //   dummyModel.org = {};
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('value.short', 'foo');
 
   //   expect(dummyChangeset.get('value.short')).toBe('foo');
@@ -1223,7 +1203,7 @@ describe('Unit | Utility | validation changeset', () => {
   it('nested objects can be replaced with different ones without changing the nested return values', () => {
     dummyModel['org'] = { usa: { ny: 'ny' } };
 
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('org', { usa: { ca: 'ca' } });
 
     expect(dummyChangeset.get('org')).toEqual({ usa: { ca: 'ca', ny: undefined } });
@@ -1241,7 +1221,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   }
   //   dummyModel['org'] = new Country({ usa: { ny: 'ny' } });
 
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('org', new Country({ usa: { ca: 'ca' } }));
 
   //   expect(dummyChangeset.get('org')).toEqual(new Country({ usa: { ca: 'ca', ny: undefined } }));
@@ -1261,7 +1241,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     landArea: 100
   //   };
 
-  //   const c: Record<string, any> = Changeset(dummyModel, userSchema);
+  //   const c: Record<string, any> = Changeset(dummyModel);
   //   c.set('org.usa.ny', 'NY');
 
   //   expect(dummyModel.org.usa.ny).toBe('ny');
@@ -1292,7 +1272,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     landArea: 100
   //   };
 
-  //   const c: any = Changeset(dummyModel, userSchema);
+  //   const c: any = Changeset(dummyModel);
   //   c.set('org.usa.ny', 'NY');
 
   //   expect(dummyModel.org.usa.ny).toBe('ny');
@@ -1315,7 +1295,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     }
   //   };
 
-  //   const c = Changeset(dummyModel, userSchema);
+  //   const c = Changeset(dummyModel);
   //   set(c, 'org.usa.ny', 'foo');
 
   //   expect(dummyModel.org.usa.ny).toBe('foo');
@@ -1328,7 +1308,7 @@ describe('Unit | Utility | validation changeset', () => {
   // it('#set use native setters at single level', () => {
   //   dummyModel.org = 'ny';
 
-  //   const c = Changeset(dummyModel, userSchema);
+  //   const c = Changeset(dummyModel);
   //   c.org = 'foo';
 
   //   expect(dummyModel.org).toBe('ny');
@@ -1345,7 +1325,7 @@ describe('Unit | Utility | validation changeset', () => {
   //       this.date = date;
   //     }
   //   }
-  //   const c = Changeset(dummyModel, userSchema);
+  //   const c = Changeset(dummyModel);
   //   const d = new Date();
   //   const momentInstance = new Moment(d);
   //   c.set('startDate', momentInstance);
@@ -1368,7 +1348,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set supports `undefined`', () => {
     const model = { name: 'foo' };
-    const dummyChangeset = Changeset(model, userSchema);
+    const dummyChangeset = Changeset(model);
 
     dummyChangeset.set('name', undefined);
     expect(dummyChangeset.name).toBeUndefined();
@@ -1377,7 +1357,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set does not add a change if new value equals old value', () => {
     const model = { name: 'foo' };
-    const dummyChangeset = Changeset(model, userSchema);
+    const dummyChangeset = Changeset(model);
 
     dummyChangeset.set('name', 'foo');
     expect(dummyChangeset.changes).toEqual({});
@@ -1408,7 +1388,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#set removes a change if set back to original value in nested context', () => {
     const model = { name: { email: 'foo' } };
-    const dummyChangeset = Changeset(model, userSchema);
+    const dummyChangeset = Changeset(model);
     dummyChangeset.safeGet = get;
 
     dummyChangeset.set('name.email', 'bar');
@@ -1423,7 +1403,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     { key: 'name', validation: 'too short', value: 'a' },
   //     { key: 'password', validation: ['foo', 'bar'], value: false }
   //   ];
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('name', 'a');
   //   dummyChangeset.set('password', false);
   //   const changes = dummyChangeset.changes;
@@ -1442,7 +1422,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#set adds errors if undefined value', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   let expectedResult = [{ key: 'name', validation: 'too short', value: undefined }];
   //   dummyChangeset.set('name', undefined);
 
@@ -1451,7 +1431,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#set if trigger null value', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   let expectedResult = [{ key: 'name', validation: 'too short', value: null }];
   //   dummyChangeset.set('name', null);
 
@@ -1460,7 +1440,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#set if trigger empty string value', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   let expectedResult = [{ key: 'name', validation: 'too short', value: '' }];
   //   dummyChangeset.set('name', '');
 
@@ -1476,7 +1456,7 @@ describe('Unit | Utility | validation changeset', () => {
       }
     };
 
-    const c = Changeset(dummyModel, userSchema);
+    const c = Changeset(dummyModel);
     c.set('org.usa.ny', 'foo');
     c.set('org.usa.ca', 'bar');
     c.set('org', 'no travelling for you');
@@ -1496,7 +1476,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     }
   //   };
 
-  //   const c = Changeset(dummyModel, userSchema);
+  //   const c = Changeset(dummyModel);
   //   c.set('org', {
   //     isCompliant: true,
   //     usa: {
@@ -1550,7 +1530,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     }
   //   };
 
-  //   const c = Changeset(dummyModel, userSchema);
+  //   const c = Changeset(dummyModel);
   //   c.set('org.usa.ny', 'NY');
   //   c.set('org.usa.mn', 'MN');
 
@@ -1625,7 +1605,7 @@ describe('Unit | Utility | validation changeset', () => {
       }
     };
 
-    const changeset = Changeset(resource, userSchema);
+    const changeset = Changeset(resource);
 
     changeset.set('styles.colors.main.sync', false);
 
@@ -1643,7 +1623,7 @@ describe('Unit | Utility | validation changeset', () => {
       }
     };
 
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     expect(dummyChangeset.get('org.asia.sg')).toBe('_initial');
 
     dummyChangeset.set('org.asia.sg', 'sg');
@@ -1661,10 +1641,10 @@ describe('Unit | Utility | validation changeset', () => {
   it('it clears errors when setting to original value', async () => {
     dummyModel.name = 'Jim Bob';
     dummyModel.age = 22;
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', '');
     try {
-      await dummyChangeset.validate();
+      await dummyChangeset.validate(changes => userSchema.validate(changes));
     } catch (e) {
       dummyChangeset.addError(e.path, { value: e.value.age, validation: e.message });
     }
@@ -1672,7 +1652,7 @@ describe('Unit | Utility | validation changeset', () => {
     expect(dummyChangeset.isValid).toEqual(false);
     dummyChangeset.set('name', 'Jim Bob');
     try {
-      await dummyChangeset.validate();
+      await dummyChangeset.validate(changes => userSchema.validate(changes));
       dummyChangeset.removeErrors();
       expect(dummyChangeset.isValid).toEqual(true);
       expect(dummyChangeset.isInvalid).toEqual(false);
@@ -1685,7 +1665,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   set(dummyModel, 'org', {
   //     usa: { ny: 'vaca' }
   //   });
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('org.usa.ny', '');
 
   //   expect(dummyChangeset.isInvalid).toEqual(true);
@@ -1698,7 +1678,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   set(dummyModel, 'org', {
   //     isCompliant: true
   //   });
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('org.isCompliant', false);
 
   //   expect(dummyChangeset.isInvalid).toEqual(true);
@@ -1712,7 +1692,7 @@ describe('Unit | Utility | validation changeset', () => {
       usa: { ny: 'i need a vacation' }
     };
 
-    const c = Changeset(dummyModel, userSchema);
+    const c = Changeset(dummyModel);
     c.set('org.usa.br', 'whoop');
 
     const actual = get(c, 'change.org.usa.ny');
@@ -1723,7 +1703,7 @@ describe('Unit | Utility | validation changeset', () => {
   it('#set works when replacing an Object with an primitive', () => {
     const model = { foo: { bar: { baz: 42 } } };
 
-    const c: any = Changeset(model, userSchema);
+    const c: any = Changeset(model);
     expect(c.foo.bar.baz).toEqual(model.foo.bar.baz);
 
     c.set('foo', 'not an object anymore');
@@ -1736,7 +1716,7 @@ describe('Unit | Utility | validation changeset', () => {
    */
 
   it('#execute applies changes to content if valid', () => {
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'foo');
 
     expect(dummyModel.name).toBeUndefined();
@@ -1748,12 +1728,12 @@ describe('Unit | Utility | validation changeset', () => {
   });
 
   it('#execute does not apply changes to content if invalid', async () => {
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'a');
 
     expect(dummyModel.name).toBeUndefined();
     try {
-      await dummyChangeset.validate();
+      await dummyChangeset.validate(changes => userSchema.validate(changes));
     } catch (e) {
       dummyChangeset.addError(e.path, { value: e.value.age, validation: e.message });
     }
@@ -1862,7 +1842,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     }
   //   };
 
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('org.asia.sg', 'sg');
   //   dummyChangeset.set('org.usa.ca', 'ca');
   //   dummyChangeset.set('org.usa.ny', 'ny');
@@ -1893,7 +1873,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   dummyModel.size = {
   //     value: 0
   //   };
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('size.value', 1001);
   //   dummyChangeset.set('size.power10', 10);
 
@@ -1908,7 +1888,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   // it('#execute works if leaf property wasnt set before', () => {
   //   dummyModel.size = {};
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('size.value', 1001);
 
   //   expect(dummyModel.size).toEqual({});
@@ -1920,7 +1900,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#execute works if root property wasnt set before', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('size.value', 1001);
 
   //   expect(dummyModel.size).toBeUndefined();
@@ -1975,7 +1955,7 @@ describe('Unit | Utility | validation changeset', () => {
       options = dummyOptions;
       return Promise.resolve('saveResult');
     };
-    const dummyChangeset = Changeset(dummyModel, userSchema);
+    const dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'foo');
 
     expect(result).toBeUndefined();
@@ -1998,7 +1978,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     options = dummyOptions;
   //     return Promise.resolve('saveResult');
   //   };
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('name', 'foo');
 
   //   expect(result).toBe(undefined);
@@ -2016,7 +1996,7 @@ describe('Unit | Utility | validation changeset', () => {
   // it('#save handles rejected proxy content', done => {
   //   expect.assertions(1);
 
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
 
   //   dummyModel['save'] = () => {
   //     return Promise.reject(new Error('some ember data error'));
@@ -2037,7 +2017,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect.assertions(2);
 
   //   dummyModel.name = 'previous';
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
+  //   const dummyChangeset = Changeset(dummyModel);
 
   //   dummyModel['save'] = () => {
   //     dummyModel.errors = [
@@ -2090,7 +2070,7 @@ describe('Unit | Utility | validation changeset', () => {
         .required()
         .min(21)
     });
-    let dummyChangeset = Changeset(dummyModel, userSchema);
+    let dummyChangeset = Changeset(dummyModel);
     let expectedChanges = {
       age: {
         current: 2,
@@ -2099,7 +2079,7 @@ describe('Unit | Utility | validation changeset', () => {
     };
     dummyChangeset.set('age', 2);
     try {
-      await dummyChangeset.validate();
+      await dummyChangeset.validate(changes => userSchema.validate(changes));
     } catch (e) {
       dummyChangeset.addError(e.path, { value: e.value.age, validation: e.message });
     }
@@ -2117,7 +2097,7 @@ describe('Unit | Utility | validation changeset', () => {
   });
 
   // it('#rollback resets valid state', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('name', 'a');
 
   //   expect(dummyChangeset.isInvalid).toBeTruthy();
@@ -2128,7 +2108,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#rollback twice works', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('name', 'abcde');
 
   //   let expectedChanges = [{ key: 'name', value: 'abcde' }];
@@ -2149,7 +2129,7 @@ describe('Unit | Utility | validation changeset', () => {
   //   dummyModel['org'] = {
   //     asia: { sg: null }
   //   };
-  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('org.asia.sg', 'sg');
 
   //   let expectedChanges = [{ key: 'org.asia.sg', value: 'sg' }];
@@ -2165,7 +2145,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#rollbackInvalid clears errors and keeps valid values', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   let expectedChanges = [
   //     { key: 'firstName', value: 'foo' },
   //     { key: 'lastName', value: 'bar' },
@@ -2188,7 +2168,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#rollbackInvalid a specific key clears key error and keeps valid values', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   let expectedChanges = [
   //     { key: 'firstName', value: 'foo' },
   //     { key: 'lastName', value: 'bar' },
@@ -2218,7 +2198,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#rollbackInvalid resets valid state', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('name', 'a');
 
   //   expect(dummyChangeset.isInvalid).toBeTruthy();
@@ -2227,7 +2207,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#rollbackInvalid will not remove changes that are valid', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('name', 'abcd');
 
   //   let expectedChanges = [{ key: 'name', value: 'abcd' }];
@@ -2239,7 +2219,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#rollbackInvalid works for keys not on changeset', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   let expectedChanges = [
   //     { key: 'firstName', value: 'foo' },
   //     { key: 'lastName', value: 'bar' },
@@ -2260,7 +2240,7 @@ describe('Unit | Utility | validation changeset', () => {
   // it('#rollbackProperty restores old value for specified property only', () => {
   //   dummyModel.firstName = 'Jim';
   //   dummyModel.lastName = 'Bob';
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   let expectedChanges = [{ key: 'lastName', value: 'bar' }];
   //   dummyChangeset.set('firstName', 'foo');
   //   dummyChangeset.set('lastName', 'bar');
@@ -2270,7 +2250,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#rollbackProperty clears errors for specified property', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   let expectedChanges = [
   //     { key: 'firstName', value: 'foo' },
   //     { key: 'lastName', value: 'bar' },
@@ -2293,7 +2273,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#rollbackProperty resets valid state', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
 
   //   expect(dummyChangeset.isInvalid).toEqual(false);
   //   expect(dummyChangeset.isValid).toEqual(true);
@@ -2325,7 +2305,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     }
   //   };
 
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('org.asia.sg', 'sg');
   //   dummyChangeset.set('org.usa.ny', 'ny');
   //   dummyChangeset.set('org.usa.ma', { name: 'Massachusetts' });
@@ -2359,10 +2339,10 @@ describe('Unit | Utility | validation changeset', () => {
       })
     });
 
-    let dummyChangeset = Changeset(dummyModel, userSchema);
+    let dummyChangeset = Changeset(dummyModel);
 
     try {
-      await dummyChangeset.validate();
+      await dummyChangeset.validate(changes => userSchema.validate(changes));
     } catch (e) {
       expect(e.message).toEqual('age is a required field');
       const error = dummyChangeset.addError('age', e.message);
@@ -2391,9 +2371,9 @@ describe('Unit | Utility | validation changeset', () => {
 
     dummyModel.age = 10;
     dummyModel.org = { usa: { minAge: 27 } };
-    let dummyChangeset = Changeset(dummyModel, userSchema);
+    let dummyChangeset = Changeset(dummyModel);
 
-    await dummyChangeset.validate();
+    await dummyChangeset.validate(changes => userSchema.validate(changes));
     expect(dummyChangeset.changes).toEqual({});
     expect(dummyChangeset.isValid).toEqual(true);
     expect(dummyChangeset.isInvalid).toEqual(false);
@@ -2412,10 +2392,10 @@ describe('Unit | Utility | validation changeset', () => {
     });
 
     dummyModel.org = { usa: { minAge: 7 } };
-    let dummyChangeset = Changeset(dummyModel, userSchema);
+    let dummyChangeset = Changeset(dummyModel);
 
     try {
-      await dummyChangeset.validate();
+      await dummyChangeset.validate(changes => userSchema.validate(changes));
     } catch (e) {
       expect(e.message).toEqual('org.usa.minAge must be greater than 18');
       const error = dummyChangeset.addError('org.usa.minAge', e.message);
@@ -2432,7 +2412,7 @@ describe('Unit | Utility | validation changeset', () => {
   // it('#validate/1 validates a single field immediately', async () => {
   //   dummyModel.name = 'J';
   //   dummyModel.password = '123';
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   await dummyChangeset.validate('name');
   //   expect(get(dummyChangeset, 'error.name')).toEqual({ validation: 'too short', value: 'J' });
@@ -2442,7 +2422,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   // it('#validate/1 validates with an falsey string value for the validator message', async () => {
   //   dummyModel.age = 120;
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   await dummyChangeset.validate('age');
   //   expect(get(dummyChangeset, 'error.age')).toEqual({ validation: '', value: 120 });
@@ -2453,7 +2433,7 @@ describe('Unit | Utility | validation changeset', () => {
   // it('#validate validates a multiple field immediately', async () => {
   //   dummyModel.name = 'J';
   //   dummyModel.password = false;
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   await dummyChangeset.validate('name', 'password');
   //   expect(get(dummyChangeset, 'error.name')).toEqual({ validation: 'too short', value: 'J' });
@@ -2467,7 +2447,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   // it('#validate/1 validates a property with no validation', async () => {
   //   dummyModel.org = {};
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   await dummyChangeset.validate('org');
   //   expect(get(dummyChangeset, 'error.org')).toEqual(undefined);
@@ -2497,7 +2477,7 @@ describe('Unit | Utility | validation changeset', () => {
   //       }
   //     }
   //   };
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   expect(get(dummyChangeset, 'errors.length')).toBe(0);
 
@@ -2536,7 +2516,7 @@ describe('Unit | Utility | validation changeset', () => {
 
   // it('#validate works correctly with complex values', () => {
   //   dummyModel = {};
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   dummyChangeset.set('options', { persist: true });
   //   dummyChangeset.validate();
@@ -2548,7 +2528,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     ...dummyModel,
   //     ...{ name: 'Jim Bob', password: true, passwordConfirmation: true, async: true }
   //   };
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   dummyChangeset.set('name', 'foo bar');
   //   dummyChangeset.set('password', false);
@@ -2589,7 +2569,7 @@ describe('Unit | Utility | validation changeset', () => {
   //       }
   //     }
   //   };
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   dummyChangeset.set('options', options);
 
@@ -2605,7 +2585,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     }
   //   };
 
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
   //   await dummyChangeset.validate('org.usa.ny');
   //   expect(get(dummyChangeset, 'error.org.usa.ny')).toEqual({
   //     validation: ['must be present'],
@@ -2620,7 +2600,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     ...dummyModel,
   //     ...{ name: 'Jim Bob', password: true, passwordConfirmation: true }
   //   };
-  //   let dummyChangeset = Changeset(dummyModel, userSchema), dummyValidations);
+  //   let dummyChangeset = Changeset(dummyModel), dummyValidations);
 
   //   dummyChangeset.set('name', 'foo bar');
   //   dummyChangeset.set('password', false);
@@ -2642,7 +2622,7 @@ describe('Unit | Utility | validation changeset', () => {
     let userSchema = object({
       email: string().email()
     });
-    let dummyChangeset = Changeset(dummyModel, userSchema);
+    let dummyChangeset = Changeset(dummyModel);
     dummyChangeset.addError('email', {
       value: 'jim@bob.com',
       validation: 'Email already taken'
@@ -2651,13 +2631,13 @@ describe('Unit | Utility | validation changeset', () => {
     expect(dummyChangeset.isInvalid).toEqual(true);
     expect(get(dummyChangeset, 'error.email.validation')).toBe('Email already taken');
     dummyChangeset.set('email', 'unique@email.com');
-    await dummyChangeset.validate();
+    await dummyChangeset.validate(changes => userSchema.validate(changes));
     dummyChangeset.removeError('email');
     expect(dummyChangeset.isValid).toEqual(true);
   });
 
   // it('#addError adds an error then validates', async () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.addError('email', {
   //     value: 'jim@bob.com',
   //     validation: 'Email already taken'
@@ -2675,7 +2655,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#addError adds an error to the changeset using the shortcut', function() {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('email', 'jim@bob.com');
   //   dummyChangeset.addError('email', 'Email already taken');
 
@@ -2689,7 +2669,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#addError adds an error to the changeset on a nested property', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.addError('email.localPart', 'Cannot contain +');
 
   //   expect(dummyChangeset.isInvalid).toEqual(true);
@@ -2699,7 +2679,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#addError adds an array of errors to the changeset', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.addError('email', ['jim@bob.com', 'Email already taken']);
 
   //   expect(dummyChangeset.isInvalid).toEqual(true);
@@ -2716,7 +2696,7 @@ describe('Unit | Utility | validation changeset', () => {
   //  */
 
   // it('#pushErrors pushes an error into an array of existing validations', function() {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.set('email', 'jim@bob.com');
   //   dummyChangeset.addError('email', 'Email already taken');
   //   dummyChangeset.pushErrors('email', 'Invalid email format');
@@ -2734,7 +2714,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#pushErrors pushes an error if no existing validations are present', function() {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema));
+  //   let dummyChangeset = Changeset(dummyModel));
   //   dummyChangeset.set('name', 'J');
   //   dummyChangeset.pushErrors('name', 'cannot be J');
 
@@ -2748,7 +2728,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#pushErrors adds an error to the changeset on a nested property', () => {
-  //   let dummyChangeset = Changeset(dummyModel, userSchema);
+  //   let dummyChangeset = Changeset(dummyModel);
   //   dummyChangeset.pushErrors('email.localPart', 'Cannot contain +');
   //   dummyChangeset.pushErrors('email.localPart', 'is too short');
 
@@ -2770,10 +2750,10 @@ describe('Unit | Utility | validation changeset', () => {
     let userSchema = object({
       password: string().min(8)
     });
-    let dummyChangeset = Changeset(dummyModel, userSchema);
+    let dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'Pokemon Go');
     dummyChangeset.set('password', 'test');
-    const error = dummyChangeset.validateSync();
+    const error = dummyChangeset.validate(changes => userSchema.validateSync(changes));
     try {
       await error;
     } catch (e) {
@@ -2804,8 +2784,8 @@ describe('Unit | Utility | validation changeset', () => {
   //  */
 
   // it('#restore restores a snapshot of the changeset', () => {
-  //   let dummyChangesetA = Changeset(dummyModel, userSchema));
-  //   let dummyChangesetB = Changeset(dummyModel, userSchema));
+  //   let dummyChangesetA = Changeset(dummyModel));
+  //   let dummyChangesetB = Changeset(dummyModel));
   //   dummyChangesetA.set('name', 'Pokemon Go');
   //   dummyChangesetA.set('password', false);
   //   let snapshot = dummyChangesetA.snapshot();
@@ -2846,7 +2826,7 @@ describe('Unit | Utility | validation changeset', () => {
   //  */
 
   // it('#cast allows only specified keys to exist on the changeset', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   const expectedResult = [
   //     { key: 'name', value: 'Pokemon Go' },
   //     { key: 'password', value: true }
@@ -2862,7 +2842,7 @@ describe('Unit | Utility | validation changeset', () => {
   // });
 
   // it('#cast noops if no keys are passed', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
   //   const expectedResult = [
   //     { key: 'name', value: 'Pokemon Go' },
   //     { key: 'password', value: true },
@@ -3003,7 +2983,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     usa: { ny: null }
   //   };
 
-  //   const c = Changeset(dummyModel, userSchema), dummyValidations);
+  //   const c = Changeset(dummyModel), dummyValidations);
   //   c.validate('org.usa.ny')
   //     .then(() => c.set('org.usa.ny', 'should not fail'))
   //     .finally(done());
@@ -3024,7 +3004,7 @@ describe('Unit | Utility | validation changeset', () => {
   //     });
   //   };
 
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
+  //   const dummyChangeset = Changeset(dummyModel));
 
   //   dummyChangeset.set('delayedAsync', 'first');
   //   let firstResolver = latestDelayedAsyncResolver;
@@ -3054,7 +3034,7 @@ describe('Unit | Utility | validation changeset', () => {
   //  * #unexecute
   //  */
   // it('#unexecute after #save on new ember-data model', async () => {
-  //   const changeset = Changeset(dummyModel, userSchema);
+  //   const changeset = Changeset(dummyModel);
   //   try {
   //     changeset.unexecute();
   //     expect(true);

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -2753,7 +2753,7 @@ describe('Unit | Utility | validation changeset', () => {
     let dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'Pokemon Go');
     dummyChangeset.set('password', 'test');
-    const error = dummyChangeset.validate(changes => userSchema.validateSync(changes));
+    const error = dummyChangeset.validate(changes => userSchema.validateSync(changes, { abortEarly: false }));
     try {
       await error;
     } catch (e) {

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -2468,9 +2468,13 @@ describe('Unit | Utility | validation changeset', () => {
       'Invalid email format'
     ]);
     expect(get(dummyChangeset, 'error.email.value')).toBe('jim@bob.com');
-    expect(dummyChangeset.changes).toEqual({ email: { current: 'jim@bob.com', original: undefined } });
+    expect(dummyChangeset.changes).toEqual({
+      email: { current: 'jim@bob.com', original: undefined }
+    });
     dummyChangeset.set('email', 'unique@email.com');
-    expect(dummyChangeset.changes).toEqual({ email: { current: 'unique@email.com', original: undefined } });
+    expect(dummyChangeset.changes).toEqual({
+      email: { current: 'unique@email.com', original: undefined }
+    });
   });
 
   it('#pushErrors pushes an error if no existing validations are present', async function() {

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -5,21 +5,29 @@ import { array, object, string, number, date, InferType } from 'yup';
 
 let userSchema = object({
   name: string().required(),
-  age: number().required().positive().integer(),
+  age: number()
+    .required()
+    .positive()
+    .integer(),
   email: string().email(),
   org: object({
     usa: object({
       minAge: number().moreThan(18)
-    }),
+    })
   }),
   teams: array(string()),
-  website: string().url().nullable(),
-  createdOn: date().default(() => new Date()),
+  website: string()
+    .url()
+    .nullable(),
+  createdOn: date().default(() => new Date())
 });
 
 let dogSchema = object({
   name: string().required(),
-  age: number().required().positive().integer(),
+  age: number()
+    .required()
+    .positive()
+    .integer()
 });
 
 let dummyModel: any = {};
@@ -122,10 +130,7 @@ describe('Unit | Utility | validation changeset', () => {
    * #isValid
    */
   it('does not validate with default options', () => {
-    const dummyChangeset = Changeset(
-      dummyModel,
-      userSchema
-    );
+    const dummyChangeset = Changeset(dummyModel, userSchema);
 
     expect(dummyChangeset.get('isValid')).toBeTruthy();
   });
@@ -293,9 +298,12 @@ describe('Unit | Utility | validation changeset', () => {
 
     const d = new Date('2015');
     const momentInstance = new Moment(d);
-    const c = Changeset({
-      startDate: momentInstance
-    }, userSchema);
+    const c = Changeset(
+      {
+        startDate: momentInstance
+      },
+      userSchema
+    );
 
     const newValue = c.get('startDate');
     expect(newValue.date).toEqual(momentInstance.date);
@@ -316,9 +324,12 @@ describe('Unit | Utility | validation changeset', () => {
     const d = new Date('2015');
     const momentInstance = new Moment(d);
     momentInstance._isUTC = true;
-    const c = Changeset({
-      startDate: momentInstance
-    }, userSchema);
+    const c = Changeset(
+      {
+        startDate: momentInstance
+      },
+      userSchema
+    );
 
     let newValue = c.get('startDate');
     expect(newValue.date).toEqual(momentInstance.date);
@@ -351,9 +362,12 @@ describe('Unit | Utility | validation changeset', () => {
     const d = new Date('2015');
     const momentInstance = new Moment(d);
     momentInstance._isUTC = true;
-    const c = Changeset({
-      startDate: momentInstance
-    }, userSchema);
+    const c = Changeset(
+      {
+        startDate: momentInstance
+      },
+      userSchema
+    );
 
     let newValue = c.get('startDate');
     expect(newValue.date).toEqual(momentInstance.date);
@@ -642,7 +656,7 @@ describe('Unit | Utility | validation changeset', () => {
     expect(dummyChangeset.get('name.title.id')).toEqual('Mr');
 
     let changes = get(dummyChangeset, 'changes');
-    let expected = {'name.title': {current: title1, original: undefined}};
+    let expected = { 'name.title': { current: title1, original: undefined } };
     expect(changes).toEqual(expected);
 
     set(dummyChangeset, 'name.title', title2);
@@ -652,7 +666,7 @@ describe('Unit | Utility | validation changeset', () => {
     expect(dummyChangeset.get('name.title.id')).toEqual('Mrs');
 
     changes = get(dummyChangeset, 'changes');
-    expected = {'name.title': {current: title2, original: undefined}};
+    expected = { 'name.title': { current: title2, original: undefined } };
     expect(changes).toEqual(expected);
 
     dummyChangeset.execute();
@@ -672,7 +686,7 @@ describe('Unit | Utility | validation changeset', () => {
     expect(dummyChangeset.get('name.title.id')).toEqual('Mr');
 
     let changes = dummyChangeset.changes;
-    let expected = {'name.title': {current: title1, original: undefined}};
+    let expected = { 'name.title': { current: title1, original: undefined } };
     expect(changes).toEqual(expected);
 
     dummyChangeset.set('name.title', title2);
@@ -682,7 +696,7 @@ describe('Unit | Utility | validation changeset', () => {
     expect(dummyChangeset.get('name.title.id')).toEqual('Mrs');
 
     changes = dummyChangeset.changes;
-    expected = {'name.title': {current: title2, original: undefined}};
+    expected = { 'name.title': { current: title2, original: undefined } };
     expect(changes).toEqual(expected);
 
     dummyChangeset.execute();
@@ -730,7 +744,9 @@ describe('Unit | Utility | validation changeset', () => {
         changeset.set('contact.emails.0', 'fred@email.com');
 
         expect(changeset.get('contact.emails.0')).toEqual('fred@email.com');
-        const expected =  {'contact.emails.0': {current: 'fred@email.com', original: 'bob@email.com'} };
+        const expected = {
+          'contact.emails.0': { current: 'fred@email.com', original: 'bob@email.com' }
+        };
         expect(changeset.changes).toEqual(expected);
         expect(changeset.get('contact.emails').unwrap()).toEqual(['fred@email.com']);
 
@@ -751,7 +767,9 @@ describe('Unit | Utility | validation changeset', () => {
           'bob@email.com',
           'fred@email.com'
         ]);
-        let expected: any = { 'contact.emails.1': {current: 'fred@email.com', 'original': undefined } }
+        let expected: any = {
+          'contact.emails.1': { current: 'fred@email.com', original: undefined }
+        };
         expect(changeset.changes).toEqual(expected);
 
         changeset.set('contact.emails.3', 'greg@email.com');
@@ -763,7 +781,10 @@ describe('Unit | Utility | validation changeset', () => {
           undefined,
           'greg@email.com'
         ]);
-        expected = { 'contact.emails.1': { current: 'fred@email.com', original: undefined }, 'contact.emails.3': { current: 'greg@email.com', original: undefined } };
+        expected = {
+          'contact.emails.1': { current: 'fred@email.com', original: undefined },
+          'contact.emails.3': { current: 'greg@email.com', original: undefined }
+        };
         expect(changeset.changes).toEqual(expected);
 
         expect(changeset.change).toEqual({
@@ -781,19 +802,27 @@ describe('Unit | Utility | validation changeset', () => {
           'bob@email.com',
           'fred@email.com'
         ]);
-        let expected: any = { 'contact.emails.1': {current: 'fred@email.com', 'original': undefined } }
+        let expected: any = {
+          'contact.emails.1': { current: 'fred@email.com', original: undefined }
+        };
         expect(changeset.changes).toEqual(expected);
 
         changeset.set('contact.emails.0', null);
 
         expect(changeset.get('contact.emails.0')).toEqual(null);
         expect(changeset.get('contact.emails').unwrap()).toEqual([null, 'fred@email.com']);
-        expected = { 'contact.emails.0': { current: null, original: 'bob@email.com' }, 'contact.emails.1': { current: 'fred@email.com', original: undefined } };
+        expected = {
+          'contact.emails.0': { current: null, original: 'bob@email.com' },
+          'contact.emails.1': { current: 'fred@email.com', original: undefined }
+        };
         expect(changeset.changes).toEqual(expected);
 
         changeset.set('contact.emails.1', null);
 
-        expected = { 'contact.emails.0': { current: null, original: 'bob@email.com' }, 'contact.emails.1': { current: null, original: undefined } };
+        expected = {
+          'contact.emails.0': { current: null, original: 'bob@email.com' },
+          'contact.emails.1': { current: null, original: undefined }
+        };
         expect(changeset.get('contact.emails').unwrap()).toEqual([null, null]);
         expect(changeset.changes).toEqual(expected);
       });
@@ -808,9 +837,12 @@ describe('Unit | Utility | validation changeset', () => {
         const fred = deepObj('fred@email.com');
         const sanHolo = deepObj('sanholo@email.com');
 
-        const changeset = Changeset({
-          contacts: [bob, fred]
-        }, userSchema);
+        const changeset = Changeset(
+          {
+            contacts: [bob, fred]
+          },
+          userSchema
+        );
 
         // "Delete" array element
         changeset.set('contacts.0', null);
@@ -818,7 +850,7 @@ describe('Unit | Utility | validation changeset', () => {
         expect(changeset.isDirty).toBeTruthy();
         expect(changeset.get('contacts.0')).toEqual(null);
         expect(changeset.get('contacts')).toEqual([null, fred]);
-        let expected: any = {'contacts.0': { current: null, original: bob } };
+        let expected: any = { 'contacts.0': { current: null, original: bob } };
         expect(changeset.changes).toEqual(expected);
 
         // Set array element to entirely new object
@@ -827,7 +859,7 @@ describe('Unit | Utility | validation changeset', () => {
         expect(changeset.isDirty).toBeTruthy();
         expect(changeset.get('contacts')).toEqual([sanHolo, fred]);
         expect(changeset.get('contacts.0.emails.primary')).toEqual('sanholo@email.com');
-        expected = {'contacts.0': { current: sanHolo, original: sanHolo } }; // todo: is 'original' sanHolo concerning?
+        expected = { 'contacts.0': { current: sanHolo, original: sanHolo } }; // todo: is 'original' sanHolo concerning?
         expect(changeset.changes).toEqual(expected);
 
         // "Delete" array element again
@@ -836,7 +868,7 @@ describe('Unit | Utility | validation changeset', () => {
         expect(changeset.isDirty).toBeTruthy();
         expect(changeset.get('contacts.0')).toEqual(null);
         expect(changeset.get('contacts')).toEqual([null, fred]);
-        expected = {'contacts.0': { current: null, original: sanHolo } };
+        expected = { 'contacts.0': { current: null, original: sanHolo } };
         expect(changeset.changes).toEqual(expected);
 
         // Revert everything
@@ -1380,7 +1412,7 @@ describe('Unit | Utility | validation changeset', () => {
     dummyChangeset.safeGet = get;
 
     dummyChangeset.set('name.email', 'bar');
-    expect(dummyChangeset.changes).toEqual({ 'name.email': { current: 'bar', original: 'foo' }});
+    expect(dummyChangeset.changes).toEqual({ 'name.email': { current: 'bar', original: 'foo' } });
 
     dummyChangeset.set('name.email', 'foo');
     expect(dummyChangeset.changes).toEqual({});
@@ -1450,7 +1482,9 @@ describe('Unit | Utility | validation changeset', () => {
     c.set('org', 'no travelling for you');
 
     const actual = c.changes;
-    const expectedResult = { org: { current: 'no travelling for you', original: { usa: { ca: 'ca', ny: 'ny' } } } };
+    const expectedResult = {
+      org: { current: 'no travelling for you', original: { usa: { ca: 'ca', ny: 'ny' } } }
+    };
     expect(actual).toEqual(expectedResult);
   });
 
@@ -2041,13 +2075,15 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#rollback restores old values', async () => {
     let userSchema = object({
-      age: number().required().min(21)
+      age: number()
+        .required()
+        .min(21)
     });
     let dummyChangeset = Changeset(dummyModel, userSchema);
     let expectedChanges = {
       age: {
         current: 2,
-        original: undefined,
+        original: undefined
       }
     };
     dummyChangeset.set('age', 2);
@@ -2058,7 +2094,9 @@ describe('Unit | Utility | validation changeset', () => {
     }
 
     expect(dummyChangeset.changes).toEqual(expectedChanges);
-    let expectedErrors = [{ key: 'age', validation: 'age must be greater than or equal to 21', value: 2 }];
+    let expectedErrors = [
+      { key: 'age', validation: 'age must be greater than or equal to 21', value: 2 }
+    ];
     expect(dummyChangeset.errors).toEqual(expectedErrors);
     expect(dummyChangeset.isDirty).toBe(true);
     dummyChangeset.rollback();
@@ -2298,13 +2336,16 @@ describe('Unit | Utility | validation changeset', () => {
     expect.assertions(5);
 
     let userSchema = object({
-      age: number().required().positive().integer(),
+      age: number()
+        .required()
+        .positive()
+        .integer(),
       email: string().email(),
       org: object({
         usa: object({
           minAge: number().moreThan(18)
-        }),
-      }),
+        })
+      })
     });
 
     let dummyChangeset = Changeset(dummyModel, userSchema);
@@ -2325,13 +2366,16 @@ describe('Unit | Utility | validation changeset', () => {
 
   it('#validate/0 happy', async () => {
     let userSchema = object({
-      age: number().required().positive().integer(),
+      age: number()
+        .required()
+        .positive()
+        .integer(),
       email: string().email(),
       org: object({
         usa: object({
           minAge: number().moreThan(18)
-        }),
-      }),
+        })
+      })
     });
 
     dummyModel.age = 10;
@@ -2352,8 +2396,8 @@ describe('Unit | Utility | validation changeset', () => {
       org: object({
         usa: object({
           minAge: number().moreThan(18)
-        }),
-      }),
+        })
+      })
     });
 
     dummyModel.org = { usa: { minAge: 7 } };
@@ -2711,9 +2755,9 @@ describe('Unit | Utility | validation changeset', () => {
    */
 
   it('#snapshot creates a snapshot of the changeset', async () => {
-    expect.assertions(2)
+    expect.assertions(2);
     let userSchema = object({
-      password: string().min(8),
+      password: string().min(8)
     });
     let dummyChangeset = Changeset(dummyModel, userSchema);
     dummyChangeset.set('name', 'Pokemon Go');
@@ -2726,7 +2770,9 @@ describe('Unit | Utility | validation changeset', () => {
       let snapshot = dummyChangeset.snapshot();
       let expectedResult = {
         changes: { name: 'Pokemon Go', password: 'test' },
-        errors: { password: { validation: 'password must be at least 8 characters', value: 'test' } }
+        errors: {
+          password: { validation: 'password must be at least 8 characters', value: 'test' }
+        }
       };
 
       expect(snapshot).toEqual(expectedResult);
@@ -2738,7 +2784,7 @@ describe('Unit | Utility | validation changeset', () => {
     let snapshot = dummyChangeset.snapshot();
     let expectedResult = {
       changes: { name: 'Pokemon Go', password: 'maestro violin' },
-      errors: {},
+      errors: {}
     };
     expect(snapshot).toEqual(expectedResult);
   });

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -2753,7 +2753,9 @@ describe('Unit | Utility | validation changeset', () => {
     let dummyChangeset = Changeset(dummyModel);
     dummyChangeset.set('name', 'Pokemon Go');
     dummyChangeset.set('password', 'test');
-    const error = dummyChangeset.validate(changes => userSchema.validateSync(changes, { abortEarly: false }));
+    const error = dummyChangeset.validate(changes =>
+      userSchema.validateSync(changes, { abortEarly: false })
+    );
     try {
       await error;
     } catch (e) {

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -1,7 +1,7 @@
 import { ValidationChangeset as Changeset } from '../src';
 import get from '../src/utils/get-deep';
 import set from '../src/utils/set-deep';
-import { array, object, string, number, date, InferType } from 'yup';
+import { array, object, string, number, date } from 'yup';
 
 let userSchema = object({
   name: string().required(),
@@ -2791,7 +2791,6 @@ describe('Unit | Utility | validation changeset', () => {
     }
 
     dummyChangeset.set('password', 'maestro violin');
-    const noError = await dummyChangeset.validateSync();
     dummyChangeset.removeError('password');
     let snapshot = dummyChangeset.snapshot();
     let expectedResult = {

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -1596,79 +1596,91 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect(dummyModel.org.usa.mn).toBe('undefined');
   // });
 
-  // it('#set works for deep set and access', async () => {
-  //   const resource = {
-  //     styles: {
-  //       colors: {
-  //         main: {
-  //           sync: true,
-  //           color: '#3D3D3D',
-  //           contrastColor: '#FFFFFF',
-  //           syncedColor: '#575757',
-  //           syncedContrastColor: '#FFFFFF'
-  //         },
-  //         accent: {
-  //           sync: true,
-  //           color: '#967E6E',
-  //           contrastColor: '#ffffff',
-  //           syncedColor: '#967E6E',
-  //           syncedContrastColor: '#ffffff'
-  //         },
-  //         ambient: {
-  //           sync: true,
-  //           color: '#FFFFFF',
-  //           contrastColor: '#3D3D3D',
-  //           syncedColor: '#FFFFFF',
-  //           syncedContrastColor: '#575757'
-  //         }
-  //       }
-  //     }
-  //   };
+  it('#set works for deep set and access', async () => {
+    const resource = {
+      styles: {
+        colors: {
+          main: {
+            sync: true,
+            color: '#3D3D3D',
+            contrastColor: '#FFFFFF',
+            syncedColor: '#575757',
+            syncedContrastColor: '#FFFFFF'
+          },
+          accent: {
+            sync: true,
+            color: '#967E6E',
+            contrastColor: '#ffffff',
+            syncedColor: '#967E6E',
+            syncedContrastColor: '#ffffff'
+          },
+          ambient: {
+            sync: true,
+            color: '#FFFFFF',
+            contrastColor: '#3D3D3D',
+            syncedColor: '#FFFFFF',
+            syncedContrastColor: '#575757'
+          }
+        }
+      }
+    };
 
-  //   const changeset = Changeset(resource);
+    const changeset = Changeset(resource, userSchema);
 
-  //   changeset.set('styles.colors.main.sync', false);
+    changeset.set('styles.colors.main.sync', false);
 
-  //   const result = changeset.get('styles.colors.main');
-  //   expect(result.sync).toEqual(false);
-  // });
+    const result = changeset.get('styles.colors.main');
+    expect(result.sync).toEqual(false);
+  });
 
-  // it('#set nested objects at various level of tree will return correct values', () => {
-  //   dummyModel['org'] = {
-  //     asia: { sg: '_initial' }, // for the sake of disambiguating nulls
-  //     usa: {
-  //       ca: null,
-  //       ny: null,
-  //       ma: { name: null }
-  //     }
-  //   };
+  it('#set nested objects at various level of tree will return correct values', () => {
+    dummyModel['org'] = {
+      asia: { sg: '_initial' }, // for the sake of disambiguating nulls
+      usa: {
+        ca: null,
+        ny: null,
+        ma: { name: null }
+      }
+    };
 
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
-  //   expect(dummyChangeset.get('org.asia.sg')).toBe('_initial');
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    expect(dummyChangeset.get('org.asia.sg')).toBe('_initial');
 
-  //   dummyChangeset.set('org.asia.sg', 'sg');
-  //   expect(dummyChangeset.get('org.asia.sg')).toBe('sg');
+    dummyChangeset.set('org.asia.sg', 'sg');
+    expect(dummyChangeset.get('org.asia.sg')).toBe('sg');
 
-  //   dummyChangeset.get('org.asia').set('sg', 'SG');
-  //   expect(dummyChangeset.get('org.asia.sg')).toBe('SG');
+    dummyChangeset.get('org.asia').set('sg', 'SG');
+    expect(dummyChangeset.get('org.asia.sg')).toBe('SG');
 
-  //   dummyChangeset.get('org').set('asia.sg', 'sg');
-  //   expect(dummyChangeset.get('org.asia.sg')).toBe('sg');
+    dummyChangeset.get('org').set('asia.sg', 'sg');
+    expect(dummyChangeset.get('org.asia.sg')).toBe('sg');
 
-  //   expect(dummyChangeset.get('org').get('asia.sg')).toBe('sg');
-  // });
+    expect(dummyChangeset.get('org').get('asia.sg')).toBe('sg');
+  });
 
-  // it('it clears errors when setting to original value', () => {
-  //   dummyModel.name = 'Jim Bob';
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
-  //   dummyChangeset.set('name', '');
-
-  //   expect(dummyChangeset.isInvalid).toEqual(true);
-  //   expect(dummyChangeset.isValid).toEqual(false);
-  //   dummyChangeset.set('name', 'Jim Bob');
-  //   expect(dummyChangeset.isValid).toEqual(true);
-  //   expect(dummyChangeset.isInvalid).toEqual(false);
-  // });
+  it('it clears errors when setting to original value', async () => {
+    dummyModel.name = 'Jim Bob';
+    dummyModel.age = 22;
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', '');
+    try {
+      await dummyChangeset.validate();
+    } catch (e) {
+      dummyChangeset.addError(e.path, { value: e.value.age, validation: e.message });
+    }
+    expect(dummyChangeset.isInvalid).toEqual(true);
+    expect(dummyChangeset.isValid).toEqual(false);
+    dummyChangeset.set('name', 'Jim Bob');
+    try {
+      await dummyChangeset.validate();
+    } catch (e) {
+      throw Error('error');
+    } finally {
+      dummyChangeset.removeError('name');
+      expect(dummyChangeset.isValid).toEqual(true);
+      expect(dummyChangeset.isInvalid).toEqual(false);
+    }
+  });
 
   // it('it clears errors when setting to original value when nested', async () => {
   //   set(dummyModel, 'org', {

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -1188,17 +1188,17 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect(dummyModel.value.short).toBe('foo');
   // });
 
-  // it('nested objects can be replaced with different ones without changing the nested return values', () => {
-  //   dummyModel['org'] = { usa: { ny: 'ny' } };
+  it('nested objects can be replaced with different ones without changing the nested return values', () => {
+    dummyModel['org'] = { usa: { ny: 'ny' } };
 
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
-  //   dummyChangeset.set('org', { usa: { ca: 'ca' } });
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('org', { usa: { ca: 'ca' } });
 
-  //   expect(dummyChangeset.get('org')).toEqual({ usa: { ca: 'ca', ny: undefined } });
-  //   expect(dummyChangeset.get('org.usa')).toEqual({ ca: 'ca', ny: undefined });
-  //   expect(dummyChangeset.get('org.usa.ca')).toBe('ca');
-  //   expect(dummyChangeset.get('org.usa.ny')).toBeUndefined();
-  // });
+    expect(dummyChangeset.get('org')).toEqual({ usa: { ca: 'ca', ny: undefined } });
+    expect(dummyChangeset.get('org.usa')).toEqual({ ca: 'ca', ny: undefined });
+    expect(dummyChangeset.get('org.usa.ca')).toBe('ca');
+    expect(dummyChangeset.get('org.usa.ny')).toBeUndefined();
+  });
 
   // it('nested objects can be replaced with different ones as classes', () => {
   //   class Country {
@@ -1334,22 +1334,22 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect(newValue.date).toEqual(d);
   // });
 
-  // it('#set supports `undefined`', () => {
-  //   const model = { name: 'foo' };
-  //   const dummyChangeset = Changeset(model);
+  it('#set supports `undefined`', () => {
+    const model = { name: 'foo' };
+    const dummyChangeset = Changeset(model, userSchema);
 
-  //   dummyChangeset.set('name', undefined);
-  //   expect(dummyChangeset.name).toBeUndefined();
-  //   expect(dummyChangeset.changes).toEqual([{ key: 'name', value: undefined }]);
-  // });
+    dummyChangeset.set('name', undefined);
+    expect(dummyChangeset.name).toBeUndefined();
+    expect(dummyChangeset.changes).toEqual({ name: { current: undefined, original: 'foo' } });
+  });
 
-  // it('#set does not add a change if new value equals old value', () => {
-  //   const model = { name: 'foo' };
-  //   const dummyChangeset = Changeset(model);
+  it('#set does not add a change if new value equals old value', () => {
+    const model = { name: 'foo' };
+    const dummyChangeset = Changeset(model, userSchema);
 
-  //   dummyChangeset.set('name', 'foo');
-  //   expect(dummyChangeset.changes).toEqual([]);
-  // });
+    dummyChangeset.set('name', 'foo');
+    expect(dummyChangeset.changes).toEqual({});
+  });
 
   // it('#set does not add a change if new value equals old value and `skipValidate` is true', () => {
   //   const model = { name: 'foo' };
@@ -1374,17 +1374,17 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect(dummyChangeset.changes).toEqual([]);
   // });
 
-  // it('#set removes a change if set back to original value in nested context', () => {
-  //   const model = { name: { email: 'foo' } };
-  //   const dummyChangeset = Changeset(model);
-  //   dummyChangeset.safeGet = get;
+  it('#set removes a change if set back to original value in nested context', () => {
+    const model = { name: { email: 'foo' } };
+    const dummyChangeset = Changeset(model, userSchema);
+    dummyChangeset.safeGet = get;
 
-  //   dummyChangeset.set('name.email', 'bar');
-  //   expect(dummyChangeset.changes).toEqual([{ key: 'name.email', value: 'bar' }]);
+    dummyChangeset.set('name.email', 'bar');
+    expect(dummyChangeset.changes).toEqual({ 'name.email': { current: 'bar', original: 'foo' }});
 
-  //   dummyChangeset.set('name.email', 'foo');
-  //   expect(dummyChangeset.changes).toEqual([]);
-  // });
+    dummyChangeset.set('name.email', 'foo');
+    expect(dummyChangeset.changes).toEqual({});
+  });
 
   // it('#set does add a change if invalid', () => {
   //   const expectedErrors = [
@@ -1407,22 +1407,6 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect(errors).toEqual(expectedErrors);
   //   expect(isValid).toEqual(false);
   //   expect(isInvalid).toBeTruthy();
-  // });
-
-  // it('#set adds the change without validation if `skipValidate` option is set', () => {
-  //   const expectedChanges = [{ key: 'password', value: false }];
-
-  //   const dummyChangeset = Changeset(dummyModel, userSchema), null, {
-  //     skipValidate: true
-  //   });
-
-  //   expect(dummyChangeset.isValid).toEqual(true);
-
-  //   dummyChangeset.set('password', false);
-  //   const changes = dummyChangeset.changes;
-
-  //   expect(changes).toEqual(expectedChanges);
-  //   expect(dummyChangeset.isValid).toEqual(true);
   // });
 
   // it('#set adds errors if undefined value', () => {
@@ -1452,23 +1436,23 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect(dummyChangeset.get('errors')).toEqual(expectedResult);
   // });
 
-  // it('#set should remove nested changes when setting roots', () => {
-  //   dummyModel['org'] = {
-  //     usa: {
-  //       ny: 'ny',
-  //       ca: 'ca'
-  //     }
-  //   };
+  it('#set should remove nested changes when setting roots', () => {
+    dummyModel['org'] = {
+      usa: {
+        ny: 'ny',
+        ca: 'ca'
+      }
+    };
 
-  //   const c = Changeset(dummyModel, userSchema);
-  //   c.set('org.usa.ny', 'foo');
-  //   c.set('org.usa.ca', 'bar');
-  //   c.set('org', 'no usa for you');
+    const c = Changeset(dummyModel, userSchema);
+    c.set('org.usa.ny', 'foo');
+    c.set('org.usa.ca', 'bar');
+    c.set('org', 'no travelling for you');
 
-  //   const actual = c.changes;
-  //   const expectedResult = [{ key: 'org', value: 'no usa for you' }];
-  //   expect(actual).toEqual(expectedResult);
-  // });
+    const actual = c.changes;
+    const expectedResult = { org: { current: 'no travelling for you', original: { usa: { ca: 'ca', ny: 'ny' } } } };
+    expect(actual).toEqual(expectedResult);
+  });
 
   // it('#set should handle bulk replace', () => {
   //   dummyModel['org'] = {
@@ -1640,26 +1624,6 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect(dummyChangeset.get('org').get('asia.sg')).toBe('sg');
   // });
 
-  // it('it accepts async validations', async () => {
-  //   delete dummyModel.save;
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
-  //   const expectedChanges = [{ key: 'async', value: true }];
-  //   const expectedError = { async: { validation: 'is invalid', value: 'is invalid' } };
-
-  //   dummyChangeset.set('async', true);
-  //   expect(dummyChangeset.changes).toEqual(expectedChanges);
-
-  //   dummyChangeset.set('async', 'is invalid');
-  //   expect(dummyChangeset.error).toEqual({});
-
-  //   await dummyChangeset.validate();
-  //   expect(dummyChangeset.error).toEqual(expectedError);
-
-  //   await dummyChangeset.save();
-  //   // save clears errors
-  //   expect(dummyChangeset.error).toEqual({});
-  // });
-
   // it('it clears errors when setting to original value', () => {
   //   dummyModel.name = 'Jim Bob';
   //   const dummyChangeset = Changeset(dummyModel, userSchema));
@@ -1698,99 +1662,60 @@ describe('Unit | Utility | validation changeset', () => {
   //   expect(dummyChangeset.isInvalid).toEqual(false);
   // });
 
-  // it('#set should delete nested changes when equal', () => {
-  //   dummyModel['org'] = {
-  //     usa: { ny: 'i need a vacation' }
-  //   };
+  it('#set should delete nested changes when equal', () => {
+    dummyModel['org'] = {
+      usa: { ny: 'i need a vacation' }
+    };
 
-  //   const c = Changeset(dummyModel, userSchema), dummyValidations);
-  //   c.set('org.usa.br', 'whoop');
+    const c = Changeset(dummyModel, userSchema);
+    c.set('org.usa.br', 'whoop');
 
-  //   const actual = get(c, 'change.org.usa.ny');
-  //   const expectedResult = undefined;
-  //   expect(actual).toEqual(expectedResult);
-  // });
+    const actual = get(c, 'change.org.usa.ny');
+    const expectedResult = undefined;
+    expect(actual).toEqual(expectedResult);
+  });
 
-  // it('#set works when replacing an Object with an primitive', () => {
-  //   const model = { foo: { bar: { baz: 42 } } };
+  it('#set works when replacing an Object with an primitive', () => {
+    const model = { foo: { bar: { baz: 42 } } };
 
-  //   const c: any = Changeset(model);
-  //   expect(c.foo.bar.baz).toEqual(model.foo.bar.baz);
+    const c: any = Changeset(model, userSchema);
+    expect(c.foo.bar.baz).toEqual(model.foo.bar.baz);
 
-  //   c.set('foo', 'not an object anymore');
-  //   c.execute();
-  //   expect(c.get('foo')).toEqual(model.foo);
-  // });
+    c.set('foo', 'not an object anymore');
+    c.execute();
+    expect(c.get('foo')).toEqual(model.foo);
+  });
 
-  // /**
-  //  * #prepare
-  //  */
+  /**
+   * #execute
+   */
 
-  // it('#prepare provides callback to modify changes', () => {
-  //   const date = new Date();
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
-  //   dummyChangeset.set('first_name', 'foo');
-  //   dummyChangeset.set('date_of_birth', date);
-  //   dummyChangeset.prepare(changes => {
-  //     const modified: Record<string, any> = {};
+  it('#execute applies changes to content if valid', () => {
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', 'foo');
 
-  //     for (let key in changes) {
-  //       modified[(key as string).replace(/_/g, '-')] = changes[key];
-  //     }
+    expect(dummyModel.name).toBeUndefined();
+    expect(dummyChangeset.isValid).toBeTruthy();
+    expect(dummyChangeset.isDirty).toBe(true);
+    dummyChangeset.execute();
+    expect(dummyModel.name).toBe('foo');
+    expect(dummyChangeset.isDirty).toBe(false);
+  });
 
-  //     return modified;
-  //   });
-  //   const changeKeys = dummyChangeset.changes.map(change => get(change, 'key'));
+  it('#execute does not apply changes to content if invalid', async () => {
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', 'a');
 
-  //   expect(changeKeys).toEqual(['first-name', 'date-of-birth']);
-  //   dummyChangeset.execute();
-  //   expect(dummyModel['first-name']).toEqual('foo');
-  //   expect(dummyModel['date-of-birth']).toEqual(date);
-  // });
-
-  // it('#prepare throws if callback does not return object', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
-  //   dummyChangeset.set('first_name', 'foo');
-
-  //   expect(() => dummyChangeset.prepare(() => null)).toThrow();
-  // });
-
-  // it('#prepare works with initial model containing an object property', () => {
-  //   const dummyChangeset = Changeset({ obj: {} });
-
-  //   dummyChangeset.get('obj').unwrap();
-  //   dummyChangeset.prepare(function(changes) {
-  //     return changes;
-  //   });
-
-  //   expect(dummyChangeset.isPristine).toEqual(true);
-  // });
-
-  // /**
-  //  * #execute
-  //  */
-
-  // it('#execute applies changes to content if valid', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
-  //   dummyChangeset.set('name', 'foo');
-
-  //   expect(dummyModel.name).toBeUndefined();
-  //   expect(dummyChangeset.isValid).toBeTruthy();
-  //   expect(dummyChangeset.isDirty).toBe(true);
-  //   dummyChangeset.execute();
-  //   expect(dummyModel.name).toBe('foo');
-  //   expect(dummyChangeset.isDirty).toBe(false);
-  // });
-
-  // it('#execute does not apply changes to content if invalid', () => {
-  //   const dummyChangeset = Changeset(dummyModel, userSchema));
-  //   dummyChangeset.set('name', 'a');
-
-  //   expect(dummyModel.name).toBeUndefined();
-  //   expect(dummyChangeset.isInvalid).toBeTruthy();
-  //   dummyChangeset.execute();
-  //   expect(dummyModel.name).toBeUndefined();
-  // });
+    expect(dummyModel.name).toBeUndefined();
+    try {
+      await dummyChangeset.validate();
+    } catch (e) {
+      dummyChangeset.addError(e.path, { value: e.value.age, validation: e.message });
+    }
+    expect(dummyChangeset.isInvalid).toBeTruthy();
+    dummyChangeset.execute();
+    expect(dummyModel.name).toBeUndefined();
+  });
 
   // it('#execute keeps prototype of set object', function() {
   //   class DogTag {}
@@ -1993,33 +1918,32 @@ describe('Unit | Utility | validation changeset', () => {
   //   });
   // });
 
-  // /**
-  //  * #save
-  //  */
+  /**
+   * #save
+   */
 
-  // it('#save proxies to content', done => {
-  //   let result;
-  //   let options;
-  //   dummyModel.save = (dummyOptions: Record<string, any>) => {
-  //     result = 'ok';
-  //     options = dummyOptions;
-  //     return Promise.resolve('saveResult');
-  //   };
-  //   const dummyChangeset = Changeset(dummyModel, userSchema);
-  //   dummyChangeset.set('name', 'foo');
+  it('#save proxies to content', async () => {
+    let result;
+    let options;
+    dummyModel.save = (dummyOptions: Record<string, any>) => {
+      result = 'ok';
+      options = dummyOptions;
+      return Promise.resolve('saveResult');
+    };
+    const dummyChangeset = Changeset(dummyModel, userSchema);
+    dummyChangeset.set('name', 'foo');
 
-  //   expect(result).toBeUndefined();
-  //   const promise = dummyChangeset.save({ foo: 'test options' });
-  //   expect(result).toEqual('ok');
-  //   expect(dummyChangeset.change).toEqual({});
-  //   expect(options).toEqual({ foo: 'test options' });
-  //   expect(!!promise && typeof promise.then === 'function').toBeTruthy();
-  //   promise
-  //     .then(saveResult => {
-  //       expect(saveResult).toEqual('saveResult');
-  //     })
-  //     .finally(() => done());
-  // });
+    expect(result).toBeUndefined();
+    const promise = dummyModel.save({ foo: 'test options' });
+    expect(result).toEqual('ok');
+    expect(dummyChangeset.change).toEqual({ name: 'foo' });
+    expect(options).toEqual({ foo: 'test options' });
+    expect(!!promise && typeof promise.then === 'function').toBeTruthy();
+    const saveResult = await promise;
+    expect(saveResult).toEqual('saveResult');
+    dummyChangeset.execute();
+    expect(dummyChangeset.change).toEqual({});
+  });
 
   // it('#save handles non-promise proxy content', done => {
   //   let result;


### PR DESCRIPTION
This PR adds a separate Changeset with yup compatibility.  Will be used to flush out new ideas.

Limited API compared to the original Changeset.

Yup Changeset - https://github.com/jquense/yup
- ✂️ save
- errors are required to be added to the Changeset in manually after `validate`
- ✂️ cast
- ✂️ merge
- validate takes a callback with the sum of changes.  In user land you will call `changeset.validate((changes) => yupSchema.validate(changes))`

ref https://github.com/validated-changeset/validated-changeset/issues/146

ref https://github.com/validated-changeset/validated-changeset/issues/144


```
    let userSchema = object({
      age: number().required().min(21)
    });
    let dummyChangeset = Changeset(dummyModel, userSchema);
    dummyChangeset.set('age', 2);
    try {
      await dummyChangeset.validate();
      dummyChangeset.removeErrors();
    } catch (e) {
      // without `abortEarly: false`.  Still determining what API to use from yup
      dummyChangeset.addError(e.path, { value: e.value.age, validation: e.message });
    }
```