### PR TITLE
fix rollbackInvalid removing valid changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -540,7 +540,7 @@ export class BufferedChangeset implements IChangeset {
    * @return {Changeset}
    */
   rollbackInvalid(key: string | void): this {
-    let errorKeys = keys(this[ERRORS]);
+    let errorKeys = this.errors.map(({ key }) => key);
 
     if (key) {
       this._notifyVirtualProperties([key]);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2617,6 +2617,28 @@ describe('Unit | Utility | changeset', () => {
     expect(dummyChangeset.isValid).toBeTruthy();
   });
 
+  it('#rollbackInvalid will not remove deep changes that are valid after being invalid', () => {
+    let dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations));
+    dummyChangeset.set('name', 'abcd');
+    dummyChangeset.set('org.usa.ny', '');
+
+    dummyChangeset.validate('name');
+    dummyChangeset.validate('org.usa.ny');
+
+    dummyChangeset.set('org.usa.ny', 'ny');
+    dummyChangeset.validate('org.usa.ny');
+
+    const expectedChanges = [
+      { key: 'name', value: 'abcd' },
+      { key: 'org.usa.ny', value: 'ny' }
+    ];
+
+    dummyChangeset.rollbackInvalid();
+
+    expect(dummyChangeset.changes).toEqual(expectedChanges);
+    expect(dummyChangeset.isValid).toBeTruthy();
+  });
+
   it('#rollbackInvalid works for keys not on changeset', () => {
     let dummyChangeset = Changeset(dummyModel, lookupValidator(dummyValidations));
     let expectedChanges = [


### PR DESCRIPTION
Steps to reproduce
1. Create nested property on a changeset
2. Make it fail validation
3. Set it to a valid value and validate
4. Call `rollbackInvalid()`
5. Observe that the now valid property had been removed from the changesets `changes`.

I have created this PR with a fix for this, also added a test case that can be reviewed for reproduction (without the fix the test will fail)