### PR TITLE
Fix Object.keys returning empty array on unchanged property. close #191. 

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export interface ProxyHandler {
   changes: Record<string, any>;
-  content: unknown;
+  content: Content;
   proxy: any;
   children: Record<string, any>;
   safeGet: (obj: any, key: string) => any;

--- a/src/utils/object-tree-node.ts
+++ b/src/utils/object-tree-node.ts
@@ -53,15 +53,27 @@ const objectProxyHandler = {
   },
 
   ownKeys(node: ProxyHandler): any {
-    return Reflect.ownKeys(node.changes);
+    // If changes have been made reflect the change, otherwise reflect the original content
+    if (Object.keys(node.changes).length > 0) {
+      return Reflect.ownKeys(node.changes);
+    }
+    return Reflect.ownKeys(node.content);
   },
 
   getOwnPropertyDescriptor(node: ProxyHandler, prop: string): any {
-    return Reflect.getOwnPropertyDescriptor(node.changes, prop);
+    // If changes have been made reflect the change, otherwise reflect the original content
+    if (Object.keys(node.changes).length > 0) {
+      return Reflect.getOwnPropertyDescriptor(node.changes, prop);
+    }
+    return Reflect.getOwnPropertyDescriptor(node.content, prop);
   },
 
   has(node: ProxyHandler, prop: string): any {
-    return Reflect.has(node.changes, prop);
+    // If changes have been made reflect the change, otherwise reflect the original content
+    if (Object.keys(node.changes).length > 0) {
+      return Reflect.has(node.changes, prop);
+    }
+    return Reflect.has(node.content, prop);
   },
 
   set(node: ProxyHandler, key: string, value: unknown): any {

--- a/test/validated.test.ts
+++ b/test/validated.test.ts
@@ -455,6 +455,22 @@ describe('Unit | Utility | validation changeset', () => {
       const expectedResult = get(model, 'foo.bar.dog');
       expect(actual).toEqual(expectedResult);
     }
+    {
+      // Check Object.keys is proxied to the original model when no change has been made
+      const c = Changeset(model);
+      const actual = Object.keys(get(c, 'foo'));
+      const expectedResult = Object.keys(get(model, 'foo'));
+      expect(actual).toEqual(expectedResult);
+    }
+    {
+      // Check Object.keys is proxied to the change when a change has been made
+      const c = Changeset(model);
+      const newFoo = { baz: { dog: new Dog('woof') } };
+      set(c, 'foo', newFoo);
+      const actual = Object.keys(get(c, 'foo'));
+      const expectedResult = Object.keys(newFoo);
+      expect(actual).toEqual(expectedResult);
+    }
   });
 
   it('#get proxies to underlying array properties', () => {


### PR DESCRIPTION
Fixes issue described in #191 

Not sure if there is a better way to determine if changes have been made other than testing if node.changes has no keys?