### PR TITLE
Exclude File objects from isObject test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node'
+  testEnvironment: 'jsdom'
 };

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "fs-extra": "^9.0.1",
     "gzip-size": "^5.1.1",
     "jest": "^24.9.0",
+    "jest-environment-jsdom": "^24.9.0",
     "prettier": "^2.6.2",
     "pretty-bytes": "^5.3.0",
     "release-plan": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "validated-changeset",
-  "version": "1.4.1",
+  "name": "@rs/validated-changeset",
+  "version": "1.4.2",
   "description": "Changesets for your local state",
   "keywords": [
     "changeset",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       jest:
         specifier: ^24.9.0
         version: 24.9.0
+      jest-environment-jsdom:
+        specifier: ^24.9.0
+        version: 24.9.0
       prettier:
         specifier: ^2.6.2
         version: 2.8.8

--- a/src/utils/is-object.ts
+++ b/src/utils/is-object.ts
@@ -2,7 +2,7 @@ export default function isObject<T>(val: T): boolean {
   return (
     val !== null &&
     typeof val === 'object' &&
-    !(val instanceof Date || val instanceof RegExp) &&
+    !(val instanceof Date || val instanceof RegExp || val instanceof File) &&
     !Array.isArray(val)
   );
 }

--- a/src/utils/merge-deep.ts
+++ b/src/utils/merge-deep.ts
@@ -16,7 +16,11 @@ function isNonNullObject(value: any): boolean {
 function isSpecial(value: any): boolean {
   let stringValue = Object.prototype.toString.call(value);
 
-  return stringValue === '[object RegExp]' || stringValue === '[object Date]';
+  return (
+    stringValue === '[object RegExp]' ||
+    stringValue === '[object Date]' ||
+    stringValue === '[object File]'
+  );
 }
 
 function isMergeableObject(value: any): boolean {

--- a/test/utils/is-object.test.ts
+++ b/test/utils/is-object.test.ts
@@ -26,6 +26,11 @@ describe('Unit | Utility | is object', function () {
       label: 'RegExps',
       value: /foo/,
       expected: false
+    },
+    {
+      label: 'Files',
+      value: new File([], 'fileName'),
+      expected: false
     }
   ];
 


### PR DESCRIPTION
* [TEST]: add `isObject(new File(..))'

* Modify the behavior of isObject

* `isObject(new File(..))' should return `false'